### PR TITLE
Allow non root users on a build node to delete temp files

### DIFF
--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -30,3 +30,9 @@
     src: ../templates/Jenkinsfile.j2
     dest: "/tmp/GENERATED.Jenkinsfile"
   delegate_to: localhost
+
+- name: Allow non root host to delete temp files
+  when:
+    - lookup('env', 'LOCAL') != "true"
+  command: chmod -R 777 /ansible/jenkins
+  delegate_to: localhost

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -476,10 +476,12 @@ pipeline {
                 docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
                   apk info > packages && \
                   apk info -v > versions && \
-                  paste -d " " packages versions > /tmp/package_versions.txt'
+                  paste -d " " packages versions > /tmp/package_versions.txt && \
+                  chmod 777 /tmp/package_versions.txt'
               elif [ "${DIST_IMAGE}" == "ubuntu" ]; then
                 docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  apt -qq list --installed | awk "{print \$1,\$2}" > /tmp/package_versions.txt'
+                  apt -qq list --installed | awk "{print \$1,\$2}" > /tmp/package_versions.txt && \
+                  chmod 777 /tmp/package_versions.txt'
               fi
               if [ "$(md5sum ${TEMPDIR}/package_versions.txt | cut -c1-8 )" != "${PACKAGE_TAG}" ]; then
                 git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/${LS_REPO}


### PR DESCRIPTION
Discovered this when setting up new build infra for x86 nodes. 
The temp files used during builds need to be able to be deleted by a non root user. 