### PR TITLE
changing to using the checked out package file if it exists

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -69,14 +69,10 @@ pipeline {
         script{
           env.PACKAGE_TAG = sh(
             script: '''#!/bin/bash
-                       http_code=$(curl --write-out %{http_code} -s -o /dev/null \
-                                   https://raw.githubusercontent.com/${LS_USER}/${LS_REPO}/{{ ls_branch }}/package_versions.txt)
-                       if [[ "${http_code}" -ne 200 ]] ; then
-                         echo none
+                       if [ -e package_versions.txt ] ; then
+                         cat package_versions.txt | md5sum | cut -c1-8
                        else
-                         curl -s \
-                           https://raw.githubusercontent.com/${LS_USER}/${LS_REPO}/{{ ls_branch }}/package_versions.txt \
-                         | md5sum | cut -c1-8
+                         echo none
                        fi''',
             returnStdout: true).trim()
         }


### PR DESCRIPTION
This should prevent us from hitting cached files as the files we pull during the build process are checked out at a specific commit sha. 