### PR TITLE
Only write first two columns of ubuntu apt output

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -514,7 +514,7 @@ pipeline {
                   chmod 777 /tmp/package_versions.txt'
               elif [ "${DIST_IMAGE}" == "ubuntu" ]; then
                 docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  apt list -qq --installed > /tmp/package_versions.txt && \
+                  apt list -qq --installed | cut -d" " -f1-2 > /tmp/package_versions.txt && \
                   chmod 777 /tmp/package_versions.txt'
               fi
               NEW_PACKAGE_TAG=$(md5sum ${TEMPDIR}/package_versions.txt | cut -c1-8 )


### PR DESCRIPTION
This will hit every single endpoint, not sure if we want to try to sneak in any other fixes on top of this. 
This will also trigger off package verions on Ubuntu variants so we will double build every one of those. 

We pulled it out originally because the awk logic kept messing up , cut is cleaner and does not have syntax problems being embedded in a docker exec like this. 