### PR TITLE
remove templating from baseimages

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -337,6 +337,7 @@ pipeline {
       }
     }
 {% endif %}
+{% if "docker-baseimage" not in project_name %}
     // Use helper containers to render templated files
     stage('Update-Templates') {
       when {
@@ -403,6 +404,7 @@ pipeline {
         }
       }
     }
+{% endif %}
     /* ###############
        Build Container
        ############### */


### PR DESCRIPTION
We need this to inject custom logic into the base images pending a full live deployment. 

This can be worked back in, but we might just leave it out. 