### PR TITLE
need shm size 1gb so chrome does not crash

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -632,6 +632,7 @@ pipeline {
                   docker tag lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm64v8-${META_TAG}
                 fi
                 docker run --rm \
+                --shm-size=1gb \
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -e IMAGE=\"${IMAGE}\" \
                 -e DELAY_START=\"${CI_DELAY}\" \


### PR DESCRIPTION
This has been a bug that has been a pain in my ass for some time now. 

I have been tearing apart the ci code to determine why the threads seemingly crash when taking a screenshot. 
It turns out it is a dev setting for the container that chrome requires to render complex pages properly. 
This is why the delay to render the page into an image was causing the problem to get worse as a fully rendered page is much more resource intensive to render and screenshot. 

I would normally say this should wait, but this problem leaves running containers on our x86 build nodes, we really should fix this asap.