### PR TITLE
adding option to use x86 to build if the project needs it

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -468,7 +468,11 @@ pipeline {
         }
         stage('Build ARMHF') {
           agent {
+{% if use_qemu is defined %}
+            label 'X86-64-MULTI'
+{% else %}
             label 'ARMHF'
+{% endif %}
           }
           steps {
             withCredentials([
@@ -495,7 +499,11 @@ pipeline {
         }
         stage('Build ARM64') {
           agent {
+{% if use_qemu is defined %}
+            label 'X86-64-MULTI'
+{% else %}
             label 'ARM64'
+{% endif %}
           }
           steps {
             withCredentials([


### PR DESCRIPTION
This is unobtrusive and optional, merging this will not waterfall any changes to the downstream repos. 
This option if defined in the jenkins-vars.yml will allow us to selectively build problem pojects on x86 as building them on arm has proven to be a pain. 