### PR TITLE
need to update endpoint URL as skimdb has been shut down

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -239,7 +239,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: '''curl -sL https://skimdb.npmjs.com/registry/${EXT_NPM} |jq -r '. | .["dist-tags"].latest' ''',
+            script: '''curl -sL https://replicate.npmjs.com/registry/${EXT_NPM} |jq -r '. | .["dist-tags"].latest' ''',
             returnStdout: true).trim()
           env.RELEASE_LINK = 'https://www.npmjs.com/package/' + env.EXT_NPM
         }


### PR DESCRIPTION
https://npm.community/t/skimdb-is-down-for-me-anyone-else/8060/8

We also need to swap out the dockerfile endpoint in thelounge and shout-irc.

https://github.com/linuxserver/docker-shout-irc/blob/master/Dockerfile#L24
https://github.com/linuxserver/docker-thelounge/blob/master/Dockerfile#L23