### PR TITLE
add option to rip out package check logic

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -530,6 +530,7 @@ pipeline {
         }
       }
     }
+{% if skip_package_check is not defined %}
     // Take the image we just built and dump package versions for comparison
     stage('Update-packages') {
       when {
@@ -613,6 +614,7 @@ pipeline {
         }
       }
     }
+{% endif %}
     /* #######
        Testing
        ####### */


### PR DESCRIPTION
as noted in title, this is needed for images we may generate that are unable to be run or are not ubuntu/alpine. 