### PR TITLE
need custom vars to define shm size in downstream image

### DIFF
--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -154,6 +154,16 @@ docker create \
   --device {{ item.device_host_path }}:{{ item.device_path }} `#optional` \
 {% endfor %}
 {% endif %}
+{% if custom_params is defined %}
+{% for item in custom_params %}
+  --{{ item.name }}="{{ item.value }}" \
+{% endfor %}
+{% endif %}
+{% if opt_custom_params is defined %}
+{% for item in opt_custom_params %}
+  --{{ item.name }}="{{ item.value }}" `#optional` \
+{% endfor %}
+{% endif %}
   --restart unless-stopped \
   {{ lsio_project_name_short }}/{{ project_name }}
 ```
@@ -264,6 +274,16 @@ services:
       - {{ item.device_host_path }}:{{ item.device_path }} #optional
 {% endfor %}
 {% endif %}
+{% if custom_params is defined %}
+{% for item in custom_params %}
+    {{ item.name_compose }}: "{{ item.value }}" \
+{% endfor %}
+{% endif %}
+{% if opt_custom_params is defined %}
+{% for item in opt_custom_params %}
+    {{ item.name_compose }}: "{{ item.value }}" #optional \
+{% endfor %}
+{% endif %}
     restart: unless-stopped{% else %}{{ custom_compose }}{% endif %}
 
 ```
@@ -325,6 +345,17 @@ Container images are configured using parameters passed at runtime (such as thos
 | `--device {{ item.device_path }}` | {{ item.desc }} |
 {% endfor %}
 {% endif %}
+{% if custom_params is defined %}
+{% for item in custom_params %}
+| `--{{ item.name }}=` | {{ item.desc }} |
+{% endfor %}
+{% endif %}
+{% if opt_custom_params is defined %}
+{% for item in opt_custom_params %}
+| `--{{ item.name }}=` | {{ item.desc }} |
+{% endfor %}
+{% endif %}
+
 
 ## Environment variables from files (Docker secrets)
 


### PR DESCRIPTION
Need this ability downstream in rdesktop container to define shm size. 
Will not effect any current template generation. 
Example of usage var: 
```
opt_custom_params:
  - { name: "shm-size", name_compose: "shm_size", value: "1gb",desc: "We set this to 1 gig to prevent modern web browsers from crashing" }
```