### PR TITLE
fix bug affecting multi sponsor links

### DIFF
--- a/roles/generate-jenkins/templates/FUNDING.j2
+++ b/roles/generate-jenkins/templates/FUNDING.j2
@@ -1,4 +1,4 @@
 open_collective: linuxserver
 {% if sponsor_links is defined %}
-custom: ["{% for item in sponsor_links %}{{ item.url }}",{% endfor %}]
+custom: [{% for item in sponsor_links %}"{{ item.url }}",{% endfor %}]
 {% endif %}


### PR DESCRIPTION
It shouldn't affect existing templates, only ones with multi sponsor links (ombi is the only one so far)