### PR TITLE
template again for the readme sync and use local files to update the Readme

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -679,7 +679,8 @@ pipeline {
           sh '''#! /bin/bash
                 set -e
                 TEMPDIR=$(mktemp -d)
-                docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=master -v ${TEMPDIR}:/ansible/jenkins jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}                docker pull lsiodev/readme-sync
+                docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=master -v ${TEMPDIR}:/ansible/jenkins jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER} 
+                docker pull lsiodev/readme-sync
                 docker run --rm=true \
                   -e DOCKERHUB_USERNAME=$DOCKERUSER \
                   -e DOCKERHUB_PASSWORD=$DOCKERPASS \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -677,14 +677,18 @@ pipeline {
           ]
         ]) {
           sh '''#! /bin/bash
-                docker pull lsiodev/readme-sync
+                set -e
+                TEMPDIR=$(mktemp -d)
+                docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=master -v ${TEMPDIR}:/ansible/jenkins jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}                docker pull lsiodev/readme-sync
                 docker run --rm=true \
                   -e DOCKERHUB_USERNAME=$DOCKERUSER \
                   -e DOCKERHUB_PASSWORD=$DOCKERPASS \
                   -e GIT_REPOSITORY=${LS_USER}/${LS_REPO} \
                   -e DOCKER_REPOSITORY=${IMAGE} \
                   -e GIT_BRANCH=master \
-                  lsiodev/readme-sync bash -c 'node sync' '''
+                  -v ${TEMPDIR}/docker-${CONTAINER_NAME}:/mnt \
+                  lsiodev/readme-sync bash -c 'node sync' 
+                rm -Rf ${TEMPDIR} '''
         }
       }
     }

--- a/roles/generate-jenkins/templates.yml
+++ b/roles/generate-jenkins/templates.yml
@@ -2,6 +2,7 @@
 
 templated_files:
  - { src: 'README.j2', dest: 'README.md' , readme: 'true' }
+ - { src: 'lite.j2', dest: 'README.lite' , readme: 'true' }
  - { src: 'DOCUMENTATION.j2', dest: "{{ github_project_name }}.md" , readme: 'true' }
  - { src: 'Jenkinsfile.j2', dest: 'Jenkinsfile' }
  - { src: 'LICENSE.j2', dest: 'LICENSE' }

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -922,7 +922,7 @@ pipeline {
 {% if github_project_name != "docker-jenkins-builder" %}
                 docker pull linuxserver/jenkins-builder:latest
 {% endif %}
-                docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}
+                docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %} 
                 docker pull lsiodev/readme-sync
                 docker run --rm=true \
                   -e DOCKERHUB_USERNAME=$DOCKERUSER \

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -917,6 +917,12 @@ pipeline {
           ]
         ]) {
           sh '''#! /bin/bash
+                set -e
+                TEMPDIR=$(mktemp -d)
+{% if github_project_name != "docker-jenkins-builder" %}
+                docker pull linuxserver/jenkins-builder:latest
+{% endif %}
+                docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}
                 docker pull lsiodev/readme-sync
                 docker run --rm=true \
                   -e DOCKERHUB_USERNAME=$DOCKERUSER \
@@ -924,7 +930,9 @@ pipeline {
                   -e GIT_REPOSITORY=${LS_USER}/${LS_REPO} \
                   -e DOCKER_REPOSITORY=${IMAGE} \
                   -e GIT_BRANCH=master \
-                  lsiodev/readme-sync bash -c 'node sync' '''
+                  -v ${TEMPDIR}/docker-${CONTAINER_NAME}:/mnt \
+                  lsiodev/readme-sync bash -c 'node sync' 
+                rm -Rf ${TEMPDIR} '''
         }
       }
     }

--- a/roles/generate-jenkins/templates/lite.j2
+++ b/roles/generate-jenkins/templates/lite.j2
@@ -1,0 +1,116 @@
+# [{{ lsio_project_name_short }}/{{ project_name }}]({{ project_lsio_github_repo_url }})
+
+This readme has been truncated from the full version found [HERE]({{ project_lsio_github_repo_url }})
+
+{{ project_blurb }}
+
+## Usage
+
+```
+docker create \
+  --name={{ param_container_name }} \
+{% if param_usage_include_hostname is sameas true %}
+  --hostname={{ param_hostname }} \
+{% elif param_usage_include_hostname == 'optional' %}
+  --hostname={{ param_hostname }} `#optional` \
+{% endif %}
+{% if param_usage_include_net is sameas true %}
+  --net={{ param_net }} \
+{% elif param_usage_include_net == 'optional' %}
+  --net={{ param_net }} `#optional` \
+{% endif %}
+{% if privileged is sameas true %}
+  --privileged \
+{% elif privileged == 'optional' %}
+  --privileged `#optional` \
+{% endif %}
+{% if cap_add_param %}
+{% for item in cap_add_param_vars %}
+  --cap-add={{ item.cap_add_var }} \
+{% endfor %}
+{% endif %}
+{% if opt_cap_add_param %}
+{% for item in opt_cap_add_param_vars %}
+  --cap-add={{ item.cap_add_var }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if common_param_env_vars_enabled is sameas true %}
+{% for item in common_param_env_vars %}
+  -e {{ item.env_var }}={{ item.env_value }} \
+{% endfor %}
+{% elif common_param_env_vars_enabled == 'optional' %}
+{% for item in common_param_env_vars %}
+  -e {{ item.env_var }}={{ item.env_value }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if param_usage_include_env %}
+{% for item in param_env_vars %}
+  -e {{ item.env_var }}={{ item.env_value }} \
+{% endfor %}
+{% endif %}
+{% if opt_param_usage_include_env %}
+{% for item in opt_param_env_vars %}
+  -e {{ item.env_var }}={{ item.env_value }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if param_usage_include_ports %}
+{% for item in param_ports %}
+  -p {{ item.external_port }}:{{ item.internal_port }} \
+{% endfor %}
+{% endif %}
+{% if opt_param_usage_include_ports %}
+{% for item in opt_param_ports %}
+  -p {{ item.external_port }}:{{ item.internal_port }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if param_usage_include_vols %}
+{% for item in param_volumes %}
+  -v {{ item.vol_host_path }}:{{ item.vol_path }} \
+{% endfor %}
+{% endif %}
+{% if opt_param_usage_include_vols %}
+{% for item in opt_param_volumes %}
+  -v {{ item.vol_host_path }}:{{ item.vol_path }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if param_device_map %}
+{% for item in param_devices %}
+  --device {{ item.device_host_path }}:{{ item.device_path }} \
+{% endfor %}
+{% endif %}
+{% if opt_param_device_map %}
+{% for item in opt_param_devices %}
+  --device {{ item.device_host_path }}:{{ item.device_path }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if custom_params is defined %}
+{% for item in custom_params %}
+{% if item.array is not defined %}
+  --{{ item.name }}="{{ item.value }}" \
+{% else %}
+{% for item2 in item.value %}
+  --{{ item.name }}="{{ item2 }}" \
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if opt_custom_params is defined %}
+{% for item in opt_custom_params %}
+{% if item.array is not defined %}
+  --{{ item.name }}="{{ item.value }}" `#optional` \
+{% else %}
+{% for item2 in item.value %}
+  --{{ item.name }}="{{ item2 }}" `#optional` \
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+  --restart unless-stopped \
+  {{ lsio_project_name_short }}/{{ project_name }}
+```
+
+{% if app_setup_block_enabled %}
+## Application Setup
+
+{{ app_setup_block }}
+{% endif %}

--- a/roles/generate-jenkins/templates/lite.j2-CUSTOM
+++ b/roles/generate-jenkins/templates/lite.j2-CUSTOM
@@ -1,0 +1,1 @@
+{{ full_custom_readme }}


### PR DESCRIPTION
This mounts in files from the templated stuff vs the current logic pulling it in from raw git https calls. 

When this is merged everyone needs to make sure to update their aliases to prune `README.lite` after locally templating. 