### PR TITLE
Tag images by their external version number

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -293,6 +293,7 @@ pipeline {
             env.CI_TAGS = env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER
           }
           env.META_TAG = env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER
+          env.EXT_RELEASE_TAG = env.EXT_RELEASE_CLEAN
         }
       }
     }
@@ -314,6 +315,7 @@ pipeline {
           }
           env.META_TAG = env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-dev-' + env.COMMIT_SHA
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DEV_DOCKERHUB_IMAGE + '/tags/'
+          env.EXT_RELEASE_TAG = env.EXT_RELEASE_CLEAN
         }
       }
     }
@@ -335,6 +337,7 @@ pipeline {
           env.META_TAG = env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-pr-' + env.PULL_REQUEST
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/pull/' + env.PULL_REQUEST
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.PR_DOCKERHUB_IMAGE + '/tags/'
+          env.EXT_RELEASE_TAG = env.EXT_RELEASE_CLEAN
         }
       }
     }
@@ -391,7 +394,7 @@ pipeline {
 {% if github_project_name != "docker-jenkins-builder" %}
               docker pull linuxserver/jenkins-builder:latest
 {% endif %}
-              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %} 
+              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}
               CURRENTHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
               cd ${TEMPDIR}/docker-${CONTAINER_NAME}
               NEWHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
@@ -462,7 +465,7 @@ pipeline {
              "merge_requests_access_level":"disabled",\
              "repository_access_level":"enabled",\
              "visibility":"public"}' '''
-      } 
+      }
     }
     /* ###############
        Build Container
@@ -720,8 +723,10 @@ pipeline {
                   for PUSHIMAGE in "${GITHUBIMAGE}" "${GITLABIMAGE}" "${IMAGE}"; do
                     docker tag ${IMAGE}:${META_TAG} ${PUSHIMAGE}:${META_TAG}
                     docker tag ${PUSHIMAGE}:${META_TAG} ${PUSHIMAGE}:{{ release_tag }}
+                    docker tag ${PUSHIMAGE}:${EXT_RELEASE_TAG} ${PUSHIMAGE}:{{ release_tag }}
                     docker push ${PUSHIMAGE}:{{ release_tag }}
                     docker push ${PUSHIMAGE}:${META_TAG}
+                    docker push ${PUSHIMAGE}:${EXT_RELEASE_TAG}
                   done
                '''
           }
@@ -729,6 +734,7 @@ pipeline {
                 for DELETEIMAGE in "${GITHUBIMAGE}" "{GITLABIMAGE}" "${IMAGE}"; do
                   docker rmi \
                   ${DELETEIMAGE}:${META_TAG} \
+                  ${DELETEIMAGE}:${EXT_RELEASE_TAG} \
                   ${DELETEIMAGE}:{{ release_tag }} || :
                 done
              '''
@@ -784,7 +790,7 @@ pipeline {
                     docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG} --os linux --arch arm
                     docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG} --os linux --arch arm64 --variant v8
                     docker manifest push --purge ${MANIFESTIMAGE}:{{ release_tag }}
-                    docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG} 
+                    docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG}
                   done
                   docker tag ${IMAGE}:amd64-${META_TAG} ${GITHUBIMAGE}:amd64-${META_TAG}
                   docker tag ${IMAGE}:arm32v7-${META_TAG} ${GITHUBIMAGE}:arm32v7-${META_TAG}


### PR DESCRIPTION
## Description:

Add the ability to tag containers by the external version number, rather than just `latest` or the lsio version.

My intention of the implementation was for it to be no additional overhead to support (although naturally will slow down the automated deployment process ever-so slightly)

## Benefits of this PR and context:

This allows users to pin their containers to the specific application version they need, and paired with tools like `watchtower`, keep the underlying OS updated, without updating the application itself.

For example:

`linuxserver/nextcloud:latest`: Always the latest version of the nextcloud container, no matter what version of nextcloud
`linuxserver/nextcloud:18.0.4-ls81`: Version 18.0.4 of nextcloud, pinned to the 81st updated of the OS

(new) `linuxserver/nextcloud:18.0.4`: Version 18.0.4 of nextcloud, but with the underlying OS being unpinned, and thus automatically updated.

Combining the `linuxserver/nextcloud:18.0.4` tag with `watchtower` allows the underlying OS to be constantly updated, but without the application being updated (which in the case of nextcloud is not an automated process).

## Source / References:
Briefly discussed in Discord at https://discordapp.com/channels/354974912613449730/354974913049919488/718925693609574590

**Note**: This PR currently won't work for multi-arch builds, as I've not edited that part of the deployment. Not entirely sure how the manifests sections of the push process works or needs changing. If someone can assist i'm happy to get those updated too!

Diff looks slightly dirty due to trailing whitespace cleanup.