### PR TITLE
Use GitHub Actions Greetings and Stale

### DIFF
--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -33,7 +33,7 @@
   loop: "{{  templated_vars  }}"
 
 - name: Inlcude template loop variables
-  include_vars: 
+  include_vars:
     file: "/ansible/roles/generate-jenkins/templates.yml"
 
 ############################
@@ -63,8 +63,24 @@
     owner: "abc"
     group: "abc"
 
+- name: create destination dir for generated github workflow files
+  when: lookup('env', 'LOCAL') == "true"
+  file:
+    path: "/tmp/.github/workflows"
+    state: directory
+    owner: "abc"
+    group: "abc"
+
+- name: create destination dir for generated github workflow files
+  when: lookup('env', 'LOCAL') != "true"
+  file:
+    path: "jenkins/{{ github_project_name }}/.github/workflows"
+    state: directory
+    owner: "abc"
+    group: "abc"
+
 - name: create destination dir for generated donate.txt
-  when: 
+  when:
     - lookup('env', 'LOCAL') == "true"
     - sponsor_links is defined
   file:
@@ -74,7 +90,7 @@
     group: "abc"
 
 - name: create destination dir for generated donate.txt
-  when: 
+  when:
     - lookup('env', 'LOCAL') != "true"
     - sponsor_links is defined
   file:
@@ -86,7 +102,7 @@
 - name: Create symbolic link for legacy pathing
   when: lookup('env', 'LOCAL') != "true"
   shell: "ln -s {{ github_project_name }} {{ project_name }}"
-  args: 
+  args:
     chdir: /ansible/jenkins
 
 ##############################
@@ -108,7 +124,7 @@
   loop: "{{  templated_files  }}"
 
 - name: write templates local
-  when: 
+  when:
     - lookup('env', 'LOCAL') == "true"
     - item.readme is not defined
     - item.donate is not defined
@@ -149,7 +165,7 @@
   loop: "{{  templated_files  }}"
 
 - name: write readme full custom
-  when: 
+  when:
     - lookup('env', 'LOCAL') != "true"
     - item.readme is defined
     - full_custom_readme is defined
@@ -177,7 +193,7 @@
 # Donation links templating
 
 - name: write donation links
-  when: 
+  when:
     - lookup('env', 'LOCAL') != "true"
     - item.donate is defined
     - sponsor_links is defined

--- a/roles/generate-jenkins/templates.yml
+++ b/roles/generate-jenkins/templates.yml
@@ -9,3 +9,5 @@ templated_files:
  - { src: 'ISSUE_TEMPLATE.j2', dest: '.github/ISSUE_TEMPLATE.md' }
  - { src: 'PULL_REQUEST_TEMPLATE.j2', dest: '.github/PULL_REQUEST_TEMPLATE.md' }
  - { src: 'DONATE.j2', dest: 'root/donate.txt' , donate: 'true' }
+ - { src: 'greetings.j2', dest: '.github/workflows/greetings.yml' }
+ - { src: 'stale.j2', dest: '.github/workflows/stale.yml' }

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -41,7 +41,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md{% if sponsor_links is defined %} ./root/donate.txt{% endif %}'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(
@@ -391,7 +391,7 @@ pipeline {
 {% if github_project_name != "docker-jenkins-builder" %}
               docker pull linuxserver/jenkins-builder:latest
 {% endif %}
-              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %} 
+              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}
               CURRENTHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
               cd ${TEMPDIR}/docker-${CONTAINER_NAME}
               NEWHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
@@ -462,7 +462,7 @@ pipeline {
              "merge_requests_access_level":"disabled",\
              "repository_access_level":"enabled",\
              "visibility":"public"}' '''
-      } 
+      }
     }
     /* ###############
        Build Container
@@ -784,7 +784,7 @@ pipeline {
                     docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG} --os linux --arch arm
                     docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG} --os linux --arch arm64 --variant v8
                     docker manifest push --purge ${MANIFESTIMAGE}:{{ release_tag }}
-                    docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG} 
+                    docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG}
                   done
                   docker tag ${IMAGE}:amd64-${META_TAG} ${GITHUBIMAGE}:amd64-${META_TAG}
                   docker tag ${IMAGE}:arm32v7-${META_TAG} ${GITHUBIMAGE}:arm32v7-${META_TAG}

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -391,7 +391,7 @@ pipeline {
 {% if github_project_name != "docker-jenkins-builder" %}
               docker pull linuxserver/jenkins-builder:latest
 {% endif %}
-              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}
+              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if github_project_name != "docker-jenkins-builder" %}linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}{{ ' ' }}
               CURRENTHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
               cd ${TEMPDIR}/docker-${CONTAINER_NAME}
               NEWHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
@@ -401,7 +401,7 @@ pipeline {
                 cd ${TEMPDIR}/repo/${LS_REPO}
                 git checkout -f {{ ls_branch }}
                 cd ${TEMPDIR}/docker-${CONTAINER_NAME}
-                mkdir -p ${TEMPDIR}/repo/${LS_REPO}/.github
+                mkdir -p ${TEMPDIR}/repo/${LS_REPO}/.github/workflows
                 cp --parents ${TEMPLATED_FILES} ${TEMPDIR}/repo/${LS_REPO}/
                 cd ${TEMPDIR}/repo/${LS_REPO}/
                 git add ${TEMPLATED_FILES}
@@ -462,7 +462,7 @@ pipeline {
              "merge_requests_access_level":"disabled",\
              "repository_access_level":"enabled",\
              "visibility":"public"}' '''
-      }
+      }{{ ' ' }}
     }
     /* ###############
        Build Container
@@ -784,7 +784,7 @@ pipeline {
                     docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG} --os linux --arch arm
                     docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG} --os linux --arch arm64 --variant v8
                     docker manifest push --purge ${MANIFESTIMAGE}:{{ release_tag }}
-                    docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG}
+                    docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG}{{ ' ' }}
                   done
                   docker tag ${IMAGE}:amd64-${META_TAG} ${GITHUBIMAGE}:amd64-${META_TAG}
                   docker tag ${IMAGE}:arm32v7-${META_TAG} ${GITHUBIMAGE}:arm32v7-${META_TAG}

--- a/roles/generate-jenkins/templates/greetings.j2
+++ b/roles/generate-jenkins/templates/greetings.j2
@@ -9,5 +9,6 @@ jobs:
     - uses: actions/first-interaction@v1
       with:
         repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
+
         issue-message: 'Thanks for opening your first issue here! Be sure to follow the [issue template]({{ project_lsio_github_repo_url }}/.github/ISSUE_TEMPLATE.md)!'
         pr-message: 'Thanks for opening this pull request! Be sure to follow the [pull request template]({{ project_lsio_github_repo_url }}/.github/PULL_REQUEST_TEMPLATE.md)!'

--- a/roles/generate-jenkins/templates/greetings.j2
+++ b/roles/generate-jenkins/templates/greetings.j2
@@ -8,6 +8,6 @@ jobs:
     steps:
     - uses: actions/first-interaction@v1
       with:
-        repo-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
         issue-message: 'Thanks for opening your first issue here! Be sure to follow the [issue template]({{ project_lsio_github_repo_url }}/.github/ISSUE_TEMPLATE.md)!'
         pr-message: 'Thanks for opening this pull request! Be sure to follow the [pull request template]({{ project_lsio_github_repo_url }}/.github/PULL_REQUEST_TEMPLATE.md)!'

--- a/roles/generate-jenkins/templates/greetings.j2
+++ b/roles/generate-jenkins/templates/greetings.j2
@@ -8,7 +8,6 @@ jobs:
     steps:
     - uses: actions/first-interaction@v1
       with:
-        repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
-
         issue-message: 'Thanks for opening your first issue here! Be sure to follow the [issue template](https://github.com/linuxserver/docker-{{ project_name }}/.github/ISSUE_TEMPLATE.md)!'
         pr-message: 'Thanks for opening this pull request! Be sure to follow the [pull request template](https://github.com/linuxserver/docker-{{ project_name }}/.github/PULL_REQUEST_TEMPLATE.md)!'
+        repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}

--- a/roles/generate-jenkins/templates/greetings.j2
+++ b/roles/generate-jenkins/templates/greetings.j2
@@ -10,5 +10,5 @@ jobs:
       with:
         repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
 
-        issue-message: 'Thanks for opening your first issue here! Be sure to follow the [issue template]({{ project_lsio_github_repo_url }}/.github/ISSUE_TEMPLATE.md)!'
-        pr-message: 'Thanks for opening this pull request! Be sure to follow the [pull request template]({{ project_lsio_github_repo_url }}/.github/PULL_REQUEST_TEMPLATE.md)!'
+        issue-message: 'Thanks for opening your first issue here! Be sure to follow the [issue template](https://github.com/linuxserver/docker-{{ project_name }}/.github/ISSUE_TEMPLATE.md)!'
+        pr-message: 'Thanks for opening this pull request! Be sure to follow the [pull request template](https://github.com/linuxserver/docker-{{ project_name }}/.github/PULL_REQUEST_TEMPLATE.md)!'

--- a/roles/generate-jenkins/templates/greetings.j2
+++ b/roles/generate-jenkins/templates/greetings.j2
@@ -1,0 +1,13 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/first-interaction@v1
+      with:
+        repo-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        issue-message: 'Thanks for opening your first issue here! Be sure to follow the [issue template]({{ project_lsio_github_repo_url }}/.github/ISSUE_TEMPLATE.md)!'
+        pr-message: 'Thanks for opening this pull request! Be sure to follow the [pull request template]({{ project_lsio_github_repo_url }}/.github/PULL_REQUEST_TEMPLATE.md)!'

--- a/roles/generate-jenkins/templates/stale.j2
+++ b/roles/generate-jenkins/templates/stale.j2
@@ -12,8 +12,6 @@ jobs:
     steps:
     - uses: actions/stale@v1
       with:
-        repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
-
         stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         stale-issue-label: 'no-issue-activity'
@@ -22,3 +20,4 @@ jobs:
         days-before-close: 365
         exempt-issue-labels: 'awaiting-approval,work-in-progress'
         exempt-pr-labels: 'awaiting-approval,work-in-progress'
+        repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}

--- a/roles/generate-jenkins/templates/stale.j2
+++ b/roles/generate-jenkins/templates/stale.j2
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/stale@v1
       with:
-        repo-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
         stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         stale-issue-label: 'no-issue-activity'

--- a/roles/generate-jenkins/templates/stale.j2
+++ b/roles/generate-jenkins/templates/stale.j2
@@ -17,3 +17,7 @@ jobs:
         stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
+        days-before-stale: 30
+        days-before-close: 365
+        exempt-issue-labels: 'awaiting-approval,work-in-progress'
+        exempt-pr-labels: 'awaiting-approval,work-in-progress'

--- a/roles/generate-jenkins/templates/stale.j2
+++ b/roles/generate-jenkins/templates/stale.j2
@@ -1,0 +1,19 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
+        stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'

--- a/roles/generate-jenkins/templates/stale.j2
+++ b/roles/generate-jenkins/templates/stale.j2
@@ -13,6 +13,7 @@ jobs:
     - uses: actions/stale@v1
       with:
         repo-token: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
+
         stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
         stale-issue-label: 'no-issue-activity'


### PR DESCRIPTION
https://github.com/actions/starter-workflows/blob/e11672e5a9026a98ce6235af089d3112ec93dbd5/automation/greetings.yml
https://github.com/actions/first-interaction

This will comment on the first issue and first PR anyone opens in any of our repos (so possibly 2 comments in every repo that a user interacts with). I set the message to encourage users to use the respective template for the repo.

https://github.com/actions/starter-workflows/blob/e11672e5a9026a98ce6235af089d3112ec93dbd5/automation/stale.yml
https://github.com/actions/stale

This will add a label to issues and pull requests that are considered stale after a period of inactivity. After another period the issue/pr will be closed. I'll bring this up in chat to discuss additional options (inactivity period, exempt labels, etc).

Per discussions in chat:

- `no-issue-activity` and `no-pr-activity` will be added (by the bot) to issues and PRs that become stale
- Issues and PRs will become stale after **30** days of no activity
- Stale issues and PRs will be closed (by the bot) **365** after becoming stale
- Issues and PRs with the label `awaiting-approval` or `work-in-progress` (applied/created manually if needed) will not be considered stale
- A semi-long term goal will be to reduce the **365** to a lower number (the default is **5**) over time as we adjust to the bot and the labels