### PR TITLE
Update greetings.j2

### DIFF
--- a/roles/generate-jenkins/templates/greetings.j2
+++ b/roles/generate-jenkins/templates/greetings.j2
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request, issues]
+on: [pull_request_target, issues]
 
 jobs:
   greeting:


### PR DESCRIPTION
Fixes greeting failing on PRs from forks due to permissions. A PR from a fork doesn't have permissions to create a comment because the GitHub action workflow runs on the fork (not the repo receiving the PR. This feature was recently added by GitHub to allow the workflow to run on the repo receiving the PR.