### PR TITLE
Fixes docker snippet

### DIFF
--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -9,17 +9,13 @@
 
 The [LinuxServer.io]({{ lsio_full_url }}) team brings you another container release featuring:
 
- * regular and timely application updates
- * easy user mappings (PGID, PUID)
- * custom base image with s6 overlay
- * weekly base OS updates with common layers across the entire LinuxServer.io ecosystem to minimise space usage, down time and bandwidth
- * regular security updates
+ * regular application and security updates
+ * easy user mappings via [PGID, PUID](https://docs.linuxserver.io/general/understanding-puid-and-pgid)
+ * standardised [base images](https://github.com/linuxserver?q=baseimage) using s6 overlay
+ * automatic multi architecture support and customisation via [docker mods](https://github.com/linuxserver/docker-mods)
 
 Find us at:
-* [Blog]({{ lsio_blog_url }}) - {{ lsio_blog_desc }}
-* [Discord]({{ lsio_discord_url }}) - {{ lsio_discord_desc }}
-* [Discourse]({{ lsio_discourse_url }}) - {{ lsio_discourse_desc }}
-* [Fleet]({{ lsio_fleet_url }}) - {{ lsio_fleet_desc }}
+* [Linuxserver.io]({{ lsio_full_url }}) - {{ lsio_site_desc }}
 * [GitHub]({{ lsio_github_url }}) - {{ lsio_github_desc }}
 * [Open Collective]({{ lsio_opencollective_url }}) - {{ lsio_opencollective_desc }}
 
@@ -29,7 +25,6 @@ Find us at:
 [![GitHub Release]({{ lsio_shieldsio_github_release }})]({{ project_lsio_github_repo_url }}/releases)
 [![GitHub Package Repository]({{ lsio_shieldsio_static_github_package }})]({{ project_lsio_github_repo_url }}/packages)
 [![GitLab Container Registry]({{ lsio_shieldsio_static_gitlab_registry }})](https://gitlab.com/Linuxserver.io/{{ github_project_name }}/container_registry)
-[![MicroBadger Layers]({{ lsio_shieldsio_microbadger_layers }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
 [![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }})
 [![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }})
 [![Jenkins Build]({{ lsio_shieldsio_jenkins_build }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ github_project_name }}/job/{{ ls_branch }}/)
@@ -44,145 +39,14 @@ Find us at:
 
 [![{{ project_name }}]({{ project_logo }})]({{ project_url }})
 
-## Supported Architectures
-
-Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here]({{ lsio_blog_url }}/2019/02/21/the-lsio-pipeline-project/).
-
-Simply pulling `{{ lsio_project_name_short }}/{{ project_name }}` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
-
-The architectures supported by this image are:
-
-| Architecture | Tag |
-| :----: | --- |
-{% for item in available_architectures %}
-| {{ item.arch }} | {{ item.tag }} |
-{% endfor %}
-
-{% if development_versions %}
-## Version Tags
-
-This image provides various versions that are available via tags. `latest` tag usually provides the latest stable version. Others are considered under development and caution must be exercised when using them.
-
-| Tag | Description |
-| :----: | --- |
-{% for item in development_versions_items %}
-| {{ item.tag }} | {{ item.desc }} |
-{% endfor %}
-{% endif %}
-
 ## Usage
 
-Here are some example snippets to help you get started creating a container.
+Here is an example `docker-compose` snippet to help you get started creating the container.
 
-### docker
+{% if app_setup_block_enabled %}
+## Application Setup
 
-```
-docker create \
-  --name={{ param_container_name }} \
-{% if param_usage_include_hostname is sameas true %}
-  --hostname={{ param_hostname }} \
-{% elif param_usage_include_hostname == 'optional' %}
-  --hostname={{ param_hostname }} `#optional` \
-{% endif %}
-{% if param_usage_include_net is sameas true %}
-  --net={{ param_net }} \
-{% elif param_usage_include_net == 'optional' %}
-  --net={{ param_net }} `#optional` \
-{% endif %}
-{% if privileged is sameas true %}
-  --privileged \
-{% elif privileged == 'optional' %}
-  --privileged `#optional` \
-{% endif %}
-{% if cap_add_param %}
-{% for item in cap_add_param_vars %}
-  --cap-add={{ item.cap_add_var }} \
-{% endfor %}
-{% endif %}
-{% if opt_cap_add_param %}
-{% for item in opt_cap_add_param_vars %}
-  --cap-add={{ item.cap_add_var }} `#optional` \
-{% endfor %}
-{% endif %}
-{% if common_param_env_vars_enabled is sameas true %}
-{% for item in common_param_env_vars %}
-  -e {{ item.env_var }}={{ item.env_value }} \
-{% endfor %}
-{% elif common_param_env_vars_enabled == 'optional' %}
-{% for item in common_param_env_vars %}
-  -e {{ item.env_var }}={{ item.env_value }} `#optional` \
-{% endfor %}
-{% endif %}
-{% if param_usage_include_env %}
-{% for item in param_env_vars %}
-  -e {{ item.env_var }}={{ item.env_value }} \
-{% endfor %}
-{% endif %}
-{% if opt_param_usage_include_env %}
-{% for item in opt_param_env_vars %}
-  -e {{ item.env_var }}={{ item.env_value }} `#optional` \
-{% endfor %}
-{% endif %}
-{% if param_usage_include_ports %}
-{% for item in param_ports %}
-  -p {{ item.external_port }}:{{ item.internal_port }} \
-{% endfor %}
-{% endif %}
-{% if opt_param_usage_include_ports %}
-{% for item in opt_param_ports %}
-  -p {{ item.external_port }}:{{ item.internal_port }} `#optional` \
-{% endfor %}
-{% endif %}
-{% if param_usage_include_vols %}
-{% for item in param_volumes %}
-  -v {{ item.vol_host_path }}:{{ item.vol_path }} \
-{% endfor %}
-{% endif %}
-{% if opt_param_usage_include_vols %}
-{% for item in opt_param_volumes %}
-  -v {{ item.vol_host_path }}:{{ item.vol_path }} `#optional` \
-{% endfor %}
-{% endif %}
-{% if param_device_map %}
-{% for item in param_devices %}
-  --device {{ item.device_host_path }}:{{ item.device_path }} \
-{% endfor %}
-{% endif %}
-{% if opt_param_device_map %}
-{% for item in opt_param_devices %}
-  --device {{ item.device_host_path }}:{{ item.device_path }} `#optional` \
-{% endfor %}
-{% endif %}
-{% if custom_params is defined %}
-{% for item in custom_params %}
-{% if item.array is not defined %}
-  --{{ item.name }}="{{ item.value }}" \
-{% else %}
-{% for item2 in item.value %}
-  --{{ item.name }}="{{ item2 }}" \
-{% endfor %}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% if opt_custom_params is defined %}
-{% for item in opt_custom_params %}
-{% if item.array is not defined %}
-  --{{ item.name }}="{{ item.value }}" `#optional` \
-{% else %}
-{% for item2 in item.value %}
-  --{{ item.name }}="{{ item2 }}" `#optional` \
-{% endfor %}
-{% endif %}
-{% endfor %}
-{% endif %}
-  --restart unless-stopped \
-  {{ lsio_project_name_short }}/{{ project_name }}
-```
-
-{% if optional_block_1 %}
-{% for item in optional_block_1_items %}
-{{ item }}
-{% endfor %}
+{{ app_setup_block }}
 {% endif %}
 
 ### docker-compose
@@ -393,6 +257,32 @@ As an example:
 
 Will set the environment variable `PASSWORD` based on the contents of the `/run/secrets/mysecretpassword` file.
 
+## Supported Architectures
+
+Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here]({{ lsio_blog_url }}/2019/02/21/the-lsio-pipeline-project/).
+
+Simply pulling `{{ lsio_project_name_short }}/{{ project_name }}` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
+
+The architectures supported by this image are:
+
+| Architecture | Tag |
+| :----: | --- |
+{% for item in available_architectures %}
+| {{ item.arch }} | {{ item.tag }} |
+{% endfor %}
+
+{% if development_versions %}
+## Version Tags
+
+This image provides various versions that are available via tags. `latest` tag usually provides the latest stable version. Others are considered under development and caution must be exercised when using them.
+
+| Tag | Description |
+| :----: | --- |
+{% for item in development_versions_items %}
+| {{ item.tag }} | {{ item.desc }} |
+{% endfor %}
+{% endif %}
+
 ## Umask for running applications
 
 For all of our images we provide the ability to override the default umask settings for services started within the containers using the optional `-e UMASK=022` setting.
@@ -424,16 +314,13 @@ You only need to set the PUID and PGID variables if you are mounting the /config
 {% endif %}
 
 &nbsp;
-{% if app_setup_block_enabled %}
-## Application Setup
 
-{{ app_setup_block }}
-{% endif %}
-
+{% if docker_mods %}
 ## Docker Mods
 [![Docker Mods]({{ lsio_shieldsio_dynamic_mods }})]({{ lsio_mods_url }} "{{ lsio_mods_desc }}")
 
-We publish various [Docker Mods](https://github.com/linuxserver/docker-mods) to enable additional functionality within the containers. The list of Mods available for this image (if any) can be accessed via the dynamic badge above.
+We publish various [Docker Mods](https://github.com/linuxserver/docker-mods) to enable additional functionality within our containers. The list of Mods available for this image (if any) can be accessed via the dynamic badge above.
+{% endif %}
 
 {% if nginx_reverse_proxy_snippet_enabled %}
 ## Reverse Proxy Snippet
@@ -442,48 +329,11 @@ This snippet has been tested with {{ lsio_project_name|capitalize}}'s [Let's Enc
 {{ nginx_reverse_proxy_block }}
 {% endif %}
 
-## Support Info
+## Updating the container
 
-* Shell access whilst the container is running: `docker exec -it {{ project_name }} /bin/bash`
-* To monitor the logs of the container in realtime: `docker logs -f {{ project_name }}`
-* container version number
-  * `docker inspect -f {% raw %}'{{ index .Config.Labels "build_version" }}'{% endraw %} {{ project_name }}`
-* image version number
-  * `docker inspect -f {% raw %}'{{ index .Config.Labels "build_version" }}'{% endraw %} {{ lsio_project_name_short }}/{{ project_name }}`
+Most of our images are static, versioned, and require an image update and container recreation to update the app inside. With some exceptions (ie. nextcloud, plex), we do not recommend or support updating apps inside the container.
 
-## Updating Info
-
-Most of our images are static, versioned, and require an image update and container recreation to update the app inside. With some exceptions (ie. nextcloud, plex), we do not recommend or support updating apps inside the container. Please consult the [Application Setup](#application-setup) section above to see if it is recommended for the image.
-
-Below are the instructions for updating containers:
-
-### Via Docker Run/Create
-* Update the image: `docker pull {{ lsio_project_name_short }}/{{ project_name }}`
-* Stop the running container: `docker stop {{ project_name }}`
-* Delete the container: `docker rm {{ project_name }}`
-* Recreate a new container with the same docker create parameters as instructed above (if mapped correctly to a host folder, your `/config` folder and settings will be preserved)
-* Start the new container: `docker start {{ project_name }}`
-* You can also remove the old dangling images: `docker image prune`
-
-### Via Docker Compose
-* Update all images: `docker-compose pull`
-  * or update a single image: `docker-compose pull {{ project_name }}`
-* Let compose update all containers as necessary: `docker-compose up -d`
-  * or update a single container: `docker-compose up -d {{ project_name }}`
-* You can also remove the old dangling images: `docker image prune`
-
-### Via Watchtower auto-updater (especially useful if you don't remember the original parameters)
-* Pull the latest image at its tag and replace it with the same env variables in one run:
-  ```
-  docker run --rm \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  containrrr/watchtower \
-  --run-once {{ project_name }}
-  ```
-
-**Note:** We do not endorse the use of Watchtower as a solution to automated updates of existing Docker containers. In fact we generally discourage automated updates. However, this is a useful tool for one-time manual updates of containers where you have forgotten the original parameters. In the long term, we highly recommend using Docker Compose.
-
-* You can also remove the old dangling images: `docker image prune`
+TODO: Add links to Gitbook docs page for dedicated update instructions page
 
 ## Building locally
 
@@ -497,15 +347,12 @@ docker build \
   -t {{ lsio_project_name_short }}/{{ project_name }}:latest .
 ```
 
-The ARM variants can be built on x86_64 hardware using `multiarch/qemu-user-static`
-```
-docker run --rm --privileged multiarch/qemu-user-static:register --reset
-```
+TODO: Add to Gitbook how to build ARM images on x86 hardware and link to it.
 
-Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64`.
+See our [documentation](link) for how to build ARM images on x86_64 hardware.
 
 ## Versions
 
 {% for item in changelogs %}
-* **{{ item.date }}** - {{ item.desc }}
+* `**{{ item.date }}**` - {{ item.desc }}
 {% endfor %}

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -82,17 +82,17 @@ docker create \
 {% if param_usage_include_hostname is sameas true %}
   --hostname={{ param_hostname }} \
 {% elif param_usage_include_hostname == 'optional' %}
-  --hostname={{ param_hostname }} `#optional` \
+  --hostname={{ param_hostname }} #optional \
 {% endif %}
 {% if param_usage_include_net is sameas true %}
   --net={{ param_net }} \
 {% elif param_usage_include_net == 'optional' %}
-  --net={{ param_net }} `#optional` \
+  --net={{ param_net }} #optional \
 {% endif %}
 {% if privileged is sameas true %}
   --privileged \
 {% elif privileged == 'optional' %}
-  --privileged `#optional` \
+  --privileged #optional \
 {% endif %}
 {% if cap_add_param %}
 {% for item in cap_add_param_vars %}
@@ -101,7 +101,7 @@ docker create \
 {% endif %}
 {% if opt_cap_add_param %}
 {% for item in opt_cap_add_param_vars %}
-  --cap-add={{ item.cap_add_var }} `#optional` \
+  --cap-add={{ item.cap_add_var }} #optional \
 {% endfor %}
 {% endif %}
 {% if common_param_env_vars_enabled is sameas true %}
@@ -110,7 +110,7 @@ docker create \
 {% endfor %}
 {% elif common_param_env_vars_enabled == 'optional' %}
 {% for item in common_param_env_vars %}
-  -e {{ item.env_var }}={{ item.env_value }} `#optional` \
+  -e {{ item.env_var }}={{ item.env_value }} #optional \
 {% endfor %}
 {% endif %}
 {% if param_usage_include_env %}
@@ -120,7 +120,7 @@ docker create \
 {% endif %}
 {% if opt_param_usage_include_env %}
 {% for item in opt_param_env_vars %}
-  -e {{ item.env_var }}={{ item.env_value }} `#optional` \
+  -e {{ item.env_var }}={{ item.env_value }} #optional \
 {% endfor %}
 {% endif %}
 {% if param_usage_include_ports %}
@@ -130,7 +130,7 @@ docker create \
 {% endif %}
 {% if opt_param_usage_include_ports %}
 {% for item in opt_param_ports %}
-  -p {{ item.external_port }}:{{ item.internal_port }} `#optional` \
+  -p {{ item.external_port }}:{{ item.internal_port }} #optional \
 {% endfor %}
 {% endif %}
 {% if param_usage_include_vols %}
@@ -140,7 +140,7 @@ docker create \
 {% endif %}
 {% if opt_param_usage_include_vols %}
 {% for item in opt_param_volumes %}
-  -v {{ item.vol_host_path }}:{{ item.vol_path }} `#optional` \
+  -v {{ item.vol_host_path }}:{{ item.vol_path }} #optional \
 {% endfor %}
 {% endif %}
 {% if param_device_map %}
@@ -150,7 +150,7 @@ docker create \
 {% endif %}
 {% if opt_param_device_map %}
 {% for item in opt_param_devices %}
-  --device {{ item.device_host_path }}:{{ item.device_path }} `#optional` \
+  --device {{ item.device_host_path }}:{{ item.device_path }} #optional \
 {% endfor %}
 {% endif %}
 {% if custom_params is defined %}
@@ -167,10 +167,10 @@ docker create \
 {% if opt_custom_params is defined %}
 {% for item in opt_custom_params %}
 {% if item.array is not defined %}
-  --{{ item.name }}="{{ item.value }}" `#optional` \
+  --{{ item.name }}="{{ item.value }}" #optional \
 {% else %}
 {% for item2 in item.value %}
-  --{{ item.name }}="{{ item2 }}" `#optional` \
+  --{{ item.name }}="{{ item2 }}" #optional \
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -9,13 +9,17 @@
 
 The [LinuxServer.io]({{ lsio_full_url }}) team brings you another container release featuring:
 
- * regular application and security updates
- * easy user mappings via [PGID, PUID](https://docs.linuxserver.io/general/understanding-puid-and-pgid)
- * standardised [base images](https://github.com/linuxserver?q=baseimage) using s6 overlay
- * automatic multi architecture support and customisation via [docker mods](https://github.com/linuxserver/docker-mods)
+ * regular and timely application updates
+ * easy user mappings (PGID, PUID)
+ * custom base image with s6 overlay
+ * weekly base OS updates with common layers across the entire LinuxServer.io ecosystem to minimise space usage, down time and bandwidth
+ * regular security updates
 
 Find us at:
-* [Linuxserver.io]({{ lsio_full_url }}) - {{ lsio_site_desc }}
+* [Blog]({{ lsio_blog_url }}) - {{ lsio_blog_desc }}
+* [Discord]({{ lsio_discord_url }}) - {{ lsio_discord_desc }}
+* [Discourse]({{ lsio_discourse_url }}) - {{ lsio_discourse_desc }}
+* [Fleet]({{ lsio_fleet_url }}) - {{ lsio_fleet_desc }}
 * [GitHub]({{ lsio_github_url }}) - {{ lsio_github_desc }}
 * [Open Collective]({{ lsio_opencollective_url }}) - {{ lsio_opencollective_desc }}
 
@@ -25,6 +29,7 @@ Find us at:
 [![GitHub Release]({{ lsio_shieldsio_github_release }})]({{ project_lsio_github_repo_url }}/releases)
 [![GitHub Package Repository]({{ lsio_shieldsio_static_github_package }})]({{ project_lsio_github_repo_url }}/packages)
 [![GitLab Container Registry]({{ lsio_shieldsio_static_gitlab_registry }})](https://gitlab.com/Linuxserver.io/{{ github_project_name }}/container_registry)
+[![MicroBadger Layers]({{ lsio_shieldsio_microbadger_layers }})]({{ lsio_microbadger_url }}/{{ project_name }} "{{ lsio_microbadger_desc }}")
 [![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }})
 [![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }})
 [![Jenkins Build]({{ lsio_shieldsio_jenkins_build }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ github_project_name }}/job/{{ ls_branch }}/)
@@ -39,14 +44,145 @@ Find us at:
 
 [![{{ project_name }}]({{ project_logo }})]({{ project_url }})
 
+## Supported Architectures
+
+Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here]({{ lsio_blog_url }}/2019/02/21/the-lsio-pipeline-project/).
+
+Simply pulling `{{ lsio_project_name_short }}/{{ project_name }}` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
+
+The architectures supported by this image are:
+
+| Architecture | Tag |
+| :----: | --- |
+{% for item in available_architectures %}
+| {{ item.arch }} | {{ item.tag }} |
+{% endfor %}
+
+{% if development_versions %}
+## Version Tags
+
+This image provides various versions that are available via tags. `latest` tag usually provides the latest stable version. Others are considered under development and caution must be exercised when using them.
+
+| Tag | Description |
+| :----: | --- |
+{% for item in development_versions_items %}
+| {{ item.tag }} | {{ item.desc }} |
+{% endfor %}
+{% endif %}
+
 ## Usage
 
-Here is an example `docker-compose` snippet to help you get started creating the container.
+Here are some example snippets to help you get started creating a container.
 
-{% if app_setup_block_enabled %}
-## Application Setup
+### docker
 
-{{ app_setup_block }}
+```
+docker create \
+  --name={{ param_container_name }} \
+{% if param_usage_include_hostname is sameas true %}
+  --hostname={{ param_hostname }} \
+{% elif param_usage_include_hostname == 'optional' %}
+  --hostname={{ param_hostname }} `#optional` \
+{% endif %}
+{% if param_usage_include_net is sameas true %}
+  --net={{ param_net }} \
+{% elif param_usage_include_net == 'optional' %}
+  --net={{ param_net }} `#optional` \
+{% endif %}
+{% if privileged is sameas true %}
+  --privileged \
+{% elif privileged == 'optional' %}
+  --privileged `#optional` \
+{% endif %}
+{% if cap_add_param %}
+{% for item in cap_add_param_vars %}
+  --cap-add={{ item.cap_add_var }} \
+{% endfor %}
+{% endif %}
+{% if opt_cap_add_param %}
+{% for item in opt_cap_add_param_vars %}
+  --cap-add={{ item.cap_add_var }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if common_param_env_vars_enabled is sameas true %}
+{% for item in common_param_env_vars %}
+  -e {{ item.env_var }}={{ item.env_value }} \
+{% endfor %}
+{% elif common_param_env_vars_enabled == 'optional' %}
+{% for item in common_param_env_vars %}
+  -e {{ item.env_var }}={{ item.env_value }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if param_usage_include_env %}
+{% for item in param_env_vars %}
+  -e {{ item.env_var }}={{ item.env_value }} \
+{% endfor %}
+{% endif %}
+{% if opt_param_usage_include_env %}
+{% for item in opt_param_env_vars %}
+  -e {{ item.env_var }}={{ item.env_value }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if param_usage_include_ports %}
+{% for item in param_ports %}
+  -p {{ item.external_port }}:{{ item.internal_port }} \
+{% endfor %}
+{% endif %}
+{% if opt_param_usage_include_ports %}
+{% for item in opt_param_ports %}
+  -p {{ item.external_port }}:{{ item.internal_port }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if param_usage_include_vols %}
+{% for item in param_volumes %}
+  -v {{ item.vol_host_path }}:{{ item.vol_path }} \
+{% endfor %}
+{% endif %}
+{% if opt_param_usage_include_vols %}
+{% for item in opt_param_volumes %}
+  -v {{ item.vol_host_path }}:{{ item.vol_path }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if param_device_map %}
+{% for item in param_devices %}
+  --device {{ item.device_host_path }}:{{ item.device_path }} \
+{% endfor %}
+{% endif %}
+{% if opt_param_device_map %}
+{% for item in opt_param_devices %}
+  --device {{ item.device_host_path }}:{{ item.device_path }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if custom_params is defined %}
+{% for item in custom_params %}
+{% if item.array is not defined %}
+  --{{ item.name }}="{{ item.value }}" \
+{% else %}
+{% for item2 in item.value %}
+  --{{ item.name }}="{{ item2 }}" \
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if opt_custom_params is defined %}
+{% for item in opt_custom_params %}
+{% if item.array is not defined %}
+  --{{ item.name }}="{{ item.value }}" `#optional` \
+{% else %}
+{% for item2 in item.value %}
+  --{{ item.name }}="{{ item2 }}" `#optional` \
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
+  --restart unless-stopped \
+  {{ lsio_project_name_short }}/{{ project_name }}
+```
+
+{% if optional_block_1 %}
+{% for item in optional_block_1_items %}
+{{ item }}
+{% endfor %}
 {% endif %}
 
 ### docker-compose
@@ -257,32 +393,6 @@ As an example:
 
 Will set the environment variable `PASSWORD` based on the contents of the `/run/secrets/mysecretpassword` file.
 
-## Supported Architectures
-
-Our images support multiple architectures such as `x86-64`, `arm64` and `armhf`. We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here]({{ lsio_blog_url }}/2019/02/21/the-lsio-pipeline-project/).
-
-Simply pulling `{{ lsio_project_name_short }}/{{ project_name }}` should retrieve the correct image for your arch, but you can also pull specific arch images via tags.
-
-The architectures supported by this image are:
-
-| Architecture | Tag |
-| :----: | --- |
-{% for item in available_architectures %}
-| {{ item.arch }} | {{ item.tag }} |
-{% endfor %}
-
-{% if development_versions %}
-## Version Tags
-
-This image provides various versions that are available via tags. `latest` tag usually provides the latest stable version. Others are considered under development and caution must be exercised when using them.
-
-| Tag | Description |
-| :----: | --- |
-{% for item in development_versions_items %}
-| {{ item.tag }} | {{ item.desc }} |
-{% endfor %}
-{% endif %}
-
 ## Umask for running applications
 
 For all of our images we provide the ability to override the default umask settings for services started within the containers using the optional `-e UMASK=022` setting.
@@ -314,13 +424,16 @@ You only need to set the PUID and PGID variables if you are mounting the /config
 {% endif %}
 
 &nbsp;
+{% if app_setup_block_enabled %}
+## Application Setup
 
-{% if docker_mods %}
+{{ app_setup_block }}
+{% endif %}
+
 ## Docker Mods
 [![Docker Mods]({{ lsio_shieldsio_dynamic_mods }})]({{ lsio_mods_url }} "{{ lsio_mods_desc }}")
 
-We publish various [Docker Mods](https://github.com/linuxserver/docker-mods) to enable additional functionality within our containers. The list of Mods available for this image (if any) can be accessed via the dynamic badge above.
-{% endif %}
+We publish various [Docker Mods](https://github.com/linuxserver/docker-mods) to enable additional functionality within the containers. The list of Mods available for this image (if any) can be accessed via the dynamic badge above.
 
 {% if nginx_reverse_proxy_snippet_enabled %}
 ## Reverse Proxy Snippet
@@ -329,11 +442,48 @@ This snippet has been tested with {{ lsio_project_name|capitalize}}'s [Let's Enc
 {{ nginx_reverse_proxy_block }}
 {% endif %}
 
-## Updating the container
+## Support Info
 
-Most of our images are static, versioned, and require an image update and container recreation to update the app inside. With some exceptions (ie. nextcloud, plex), we do not recommend or support updating apps inside the container.
+* Shell access whilst the container is running: `docker exec -it {{ project_name }} /bin/bash`
+* To monitor the logs of the container in realtime: `docker logs -f {{ project_name }}`
+* container version number
+  * `docker inspect -f {% raw %}'{{ index .Config.Labels "build_version" }}'{% endraw %} {{ project_name }}`
+* image version number
+  * `docker inspect -f {% raw %}'{{ index .Config.Labels "build_version" }}'{% endraw %} {{ lsio_project_name_short }}/{{ project_name }}`
 
-TODO: Add links to Gitbook docs page for dedicated update instructions page
+## Updating Info
+
+Most of our images are static, versioned, and require an image update and container recreation to update the app inside. With some exceptions (ie. nextcloud, plex), we do not recommend or support updating apps inside the container. Please consult the [Application Setup](#application-setup) section above to see if it is recommended for the image.
+
+Below are the instructions for updating containers:
+
+### Via Docker Run/Create
+* Update the image: `docker pull {{ lsio_project_name_short }}/{{ project_name }}`
+* Stop the running container: `docker stop {{ project_name }}`
+* Delete the container: `docker rm {{ project_name }}`
+* Recreate a new container with the same docker create parameters as instructed above (if mapped correctly to a host folder, your `/config` folder and settings will be preserved)
+* Start the new container: `docker start {{ project_name }}`
+* You can also remove the old dangling images: `docker image prune`
+
+### Via Docker Compose
+* Update all images: `docker-compose pull`
+  * or update a single image: `docker-compose pull {{ project_name }}`
+* Let compose update all containers as necessary: `docker-compose up -d`
+  * or update a single container: `docker-compose up -d {{ project_name }}`
+* You can also remove the old dangling images: `docker image prune`
+
+### Via Watchtower auto-updater (especially useful if you don't remember the original parameters)
+* Pull the latest image at its tag and replace it with the same env variables in one run:
+  ```
+  docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower \
+  --run-once {{ project_name }}
+  ```
+
+**Note:** We do not endorse the use of Watchtower as a solution to automated updates of existing Docker containers. In fact we generally discourage automated updates. However, this is a useful tool for one-time manual updates of containers where you have forgotten the original parameters. In the long term, we highly recommend using Docker Compose.
+
+* You can also remove the old dangling images: `docker image prune`
 
 ## Building locally
 
@@ -347,12 +497,15 @@ docker build \
   -t {{ lsio_project_name_short }}/{{ project_name }}:latest .
 ```
 
-TODO: Add to Gitbook how to build ARM images on x86 hardware and link to it.
+The ARM variants can be built on x86_64 hardware using `multiarch/qemu-user-static`
+```
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+```
 
-See our [documentation](link) for how to build ARM images on x86_64 hardware.
+Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64`.
 
 ## Versions
 
 {% for item in changelogs %}
-* `**{{ item.date }}**` - {{ item.desc }}
+* **{{ item.date }}** - {{ item.desc }}
 {% endfor %}

--- a/vars/common
+++ b/vars/common
@@ -31,16 +31,17 @@ arch_arm64: "arm64"
 arch_armhf: "armhf"
 
 # descriptions
-lsio_blog_desc: "all the things you can do with our containers including How-To guides, opinions and much more!"
+lsio_blog_desc: "How-To guides, annoucements and much more!"
 lsio_discord_desc: "realtime support / chat with the community and the team."
-lsio_discourse_desc: "post on our community forum."
+lsio_discourse_desc: "our community forum."
 lsio_fleet_desc: "an online web interface which displays all of our maintained images."
-lsio_github_desc: "view the source for all of our repositories."
+lsio_github_desc: "view the source for all of our repositories - we are 100% open-source."
 lsio_irc_desc: "on freenode at `#{{ lsio_project_name }}`. Our primary support channel is Discord."
 lsio_microbadger_desc: "Get your own version badge on microbadger.com"
 lsio_mods_desc: "view available mods for this container."
 lsio_opencollective_desc: "please consider helping us by either donating or contributing to our budget"
 lsio_podcast_desc: "on hiatus. Coming back soon (late 2018)."
+lsio_site_desc: "home to our [blog](https://blog.linuxserver.io), [forum](https://discourse.linuxserver.io), [image list](https://fleet.linuxserver.io) and more!"
 
 # asset urls
 lsio_primary_logo_url: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png
@@ -87,3 +88,5 @@ common_container_param_config_description: ""
 common_param_env_vars:
   - { env_var: "PUID", env_value: "1000", desc: "for UserID - see below for explanation" }
   - { env_var: "PGID", env_value: "1000", desc: "for GroupID - see below for explanation" }
+
+docker_mods: false

--- a/vars/common
+++ b/vars/common
@@ -31,17 +31,16 @@ arch_arm64: "arm64"
 arch_armhf: "armhf"
 
 # descriptions
-lsio_blog_desc: "How-To guides, annoucements and much more!"
+lsio_blog_desc: "all the things you can do with our containers including How-To guides, opinions and much more!"
 lsio_discord_desc: "realtime support / chat with the community and the team."
-lsio_discourse_desc: "our community forum."
+lsio_discourse_desc: "post on our community forum."
 lsio_fleet_desc: "an online web interface which displays all of our maintained images."
-lsio_github_desc: "view the source for all of our repositories - we are 100% open-source."
+lsio_github_desc: "view the source for all of our repositories."
 lsio_irc_desc: "on freenode at `#{{ lsio_project_name }}`. Our primary support channel is Discord."
 lsio_microbadger_desc: "Get your own version badge on microbadger.com"
 lsio_mods_desc: "view available mods for this container."
 lsio_opencollective_desc: "please consider helping us by either donating or contributing to our budget"
 lsio_podcast_desc: "on hiatus. Coming back soon (late 2018)."
-lsio_site_desc: "home to our [blog](https://blog.linuxserver.io), [forum](https://discourse.linuxserver.io), [image list](https://fleet.linuxserver.io) and more!"
 
 # asset urls
 lsio_primary_logo_url: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png
@@ -88,5 +87,3 @@ common_container_param_config_description: ""
 common_param_env_vars:
   - { env_var: "PUID", env_value: "1000", desc: "for UserID - see below for explanation" }
   - { env_var: "PGID", env_value: "1000", desc: "for GroupID - see below for explanation" }
-
-docker_mods: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
The default docker snippet in the readme is currently not copy/paste-able due to some errant backticks. For example:

```
docker create \
  --name=plex \
  --net=host \
  -e PUID=1000 \
  -e PGID=1000 \
  -e VERSION=docker \
  -e UMASK_SET=022 `#optional` \
  -e PLEX_CLAIM= `#optional` \
  -v /path/to/library:/config \
  -v /path/to/tvseries:/tv \
  -v /path/to/movies:/movies \
  --restart unless-stopped \
  linuxserver/plex
```

See how the optional tags have ``` `#optional` ```. I think the origin of these back ticks was to render these as code blocks but given it's already in a code block of ` ``` ` it doesn't really work as expected.

## Benefits of this PR and context:

This PR means that the docker snippet is now perfectly copy / paste-able.

## How Has This Been Tested?
Built locally using `docker run --rm   -v $(pwd):/tmp   -e LOCAL=true   -e PUID=$(id -u) -e PGID=$(id -g)   linuxserver/jenkins-builder:latest && rm -f "$(basename $PWD).md"`.

