### PR TITLE
don't include build badge if ci tests are off

### DIFF
--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -8,7 +8,9 @@
 [![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }})
 [![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }})
 [![Jenkins Build]({{ lsio_shieldsio_jenkins_build }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ github_project_name }}/job/{{ ls_branch }}/)
+{% if 'CI=\'true\'' in repo_vars %}
 [![LSIO CI]({{ lsio_shieldsio_dynamic_ci }})]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/index.html)
+{% endif %}
 
 {{ project_blurb }}
 {% if project_blurb_optional_extras_enabled %}

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -8,9 +8,11 @@
 [![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }})
 [![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }})
 [![Jenkins Build]({{ lsio_shieldsio_jenkins_build }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ github_project_name }}/job/{{ ls_branch }}/)
-{% if 'CI=\'true\'' in repo_vars %}
+{% for var in repo_vars %}
+{% if 'CI' in var and 'TRUE' in var.upper() and '_' not in var %}
 [![LSIO CI]({{ lsio_shieldsio_dynamic_ci }})]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/index.html)
 {% endif %}
+{% endfor %}
 
 {{ project_blurb }}
 {% if project_blurb_optional_extras_enabled %}

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -36,9 +36,11 @@ Find us at:
 [![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }})
 [![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }})
 [![Jenkins Build]({{ lsio_shieldsio_jenkins_build }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ github_project_name }}/job/{{ ls_branch }}/)
-{% if 'CI=\'true\'' in repo_vars %}
+{% for var in repo_vars %}
+{% if 'CI' in var and 'TRUE' in var.upper() and '_' not in var %}
 [![LSIO CI]({{ lsio_shieldsio_dynamic_ci }})]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/index.html)
 {% endif %}
+{% endfor %}
 
 {{ project_blurb }}
 {% if project_blurb_optional_extras_enabled %}

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -36,7 +36,9 @@ Find us at:
 [![Docker Pulls]({{ lsio_shieldsio_docker_pulls }})]({{ project_lsio_docker_hub_url }})
 [![Docker Stars]({{ lsio_shieldsio_docker_stars }})]({{ project_lsio_docker_hub_url }})
 [![Jenkins Build]({{ lsio_shieldsio_jenkins_build }})]({{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ github_project_name }}/job/{{ ls_branch }}/)
+{% if 'CI=\'true\'' in repo_vars %}
 [![LSIO CI]({{ lsio_shieldsio_dynamic_ci }})]({{ lsio_object_url }}/{{ lsio_project_name_short }}/{{ project_name }}/latest/index.html)
+{% endif %}
 
 {{ project_blurb }}
 {% if project_blurb_optional_extras_enabled %}


### PR DESCRIPTION
fixes the issue seen on wireguard's readme: https://github.com/linuxserver/docker-wireguard/blob/master/README.md