### PR TITLE
Add package and external triggers

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -1,0 +1,12 @@
+name: External Trigger Main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  external-trigger-master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: External Trigger
+        run: |
+          echo "external trigger running off of master branch"

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -12,7 +12,7 @@ jobs:
       - name: External Trigger
         if: github.ref == 'refs/heads/master'
         run: |
-          if [ -n ${{ secrets.PAUSE_EXTERNAL_TRIGGER_JENKINS_BUILDER_MASTER }} ]; then
+          if [ -n "${{ secrets.PAUSE_EXTERNAL_TRIGGER_JENKINS_BUILDER_MASTER }}" ]; then
             echo "Github secret PAUSE_EXTERNAL_TRIGGER_JENKINS_BUILDER_MASTER is set; skipping trigger."
             exit 0
           fi

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -12,8 +12,12 @@ jobs:
       - name: External Trigger
         if: github.ref == 'refs/heads/master'
         run: |
-          echo "external trigger running off of master branch"
-          echo "setting env vars"
+          if [ -n ${{ secrets.PAUSE_EXTERNAL_TRIGGER_JENKINS_BUILDER_MASTER }} ]; then
+            echo "Github secret PAUSE_EXTERNAL_TRIGGER_JENKINS_BUILDER_MASTER is set; skipping trigger."
+            exit 0
+          fi
+          echo "External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_JENKINS_BUILDER_MASTER\"."
+          echo "Setting env vars"
           BUILD_VERSION_ARG='BUILDER_VERSION'
           LS_USER='linuxserver'
           LS_REPO='docker-jenkins-builder'
@@ -31,6 +35,6 @@ jobs:
           CI_DOCKERENV='CI_RUN=True'
           CI_AUTH='user:password'
           CI_WEBPATH=''
-          echo "retrieving external version"
+          echo "Retrieving external version"
           echo "No external release, exiting."
           exit 0

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -7,6 +7,30 @@ jobs:
   external-trigger-master:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2.3.3
+
       - name: External Trigger
+        if: github.ref == 'refs/heads/master'
         run: |
           echo "external trigger running off of master branch"
+          echo "setting env vars"
+          BUILD_VERSION_ARG='BUILDER_VERSION'
+          LS_USER='linuxserver'
+          LS_REPO='docker-jenkins-builder'
+          CONTAINER_NAME='jenkins-builder'
+          DOCKERHUB_IMAGE='linuxserver/jenkins-builder'
+          DEV_DOCKERHUB_IMAGE='lsiodev/jenkins-builder'
+          PR_DOCKERHUB_IMAGE='lspipepr/jenkins-builder'
+          DIST_IMAGE='alpine'
+          MULTIARCH='true'
+          CI='true'
+          CI_WEB='true'
+          CI_PORT='8000'
+          CI_SSL='false'
+          CI_DELAY='60'
+          CI_DOCKERENV='CI_RUN=True'
+          CI_AUTH='user:password'
+          CI_WEBPATH=''
+          echo "retrieving external version"
+          echo "No external release, exiting."
+          exit 0

--- a/.github/workflows/external_trigger_scheduler.yml
+++ b/.github/workflows/external_trigger_scheduler.yml
@@ -24,18 +24,24 @@ jobs:
             ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/jenkins-vars.yml \
               | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
             if [ "$br" == "$ls_branch" ]; then
-              echo "it's a match, checking workflow"
+              echo "${br} is a live branch, checking workflow."
               if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/.github/workflows/external_trigger.yml > /dev/null 2>&1; then
-                echo "workflow exists, triggering"
-                curl -iX POST \
-                  -H "Authorization: token ${{ secrets.CR_PAT }}" \
-                  -H "Accept: application/vnd.github.v3+json" \
-                  -d "{\"ref\":\"refs/heads/${br}\"}" \
-                  https://api.github.com/repos/linuxserver/docker-jenkins-builder/actions/workflows/external_trigger.yml/dispatches
+                echo "Workflow exists."
+                pause_trigger="$(eval echo \${pause_external_trigger_jenkins-builder_$ls_branch})"
+                if [ -z "$pause_trigger" ]; then
+                  echo "Triggering external build for branch ${br} (you can pause this trigger by setting a github secret \"pause_external_trigger_jenkins-builder_${ls_branch}\")."
+                  curl -iX POST \
+                    -H "Authorization: token ${{ secrets.CR_PAT }}" \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    -d "{\"ref\":\"refs/heads/${br}\"}" \
+                    https://api.github.com/repos/linuxserver/docker-jenkins-builder/actions/workflows/external_trigger.yml/dispatches
+                else
+                  echo "Github secret \"pause_external_trigger_jenkins-builder_${ls_branch}\" is set; skipping trigger."
+                fi
               else
-                echo "workflow doesn't exist, skipping"
+                echo "Workflow doesn't exist; skipping trigger."
               fi
             else
-              echo "no match, skipping"
+              echo "${br} appears to be a dev branch; skipping trigger."
             fi
           done

--- a/.github/workflows/external_trigger_scheduler.yml
+++ b/.github/workflows/external_trigger_scheduler.yml
@@ -1,0 +1,41 @@
+name: External Trigger Scheduler
+
+on:
+  schedule:
+    - cron:  '02 * * * *'
+  workflow_dispatch:
+
+jobs:
+  external-trigger-scheduler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: '0'
+        
+      - name: External Trigger Scheduler
+        run: |
+          git for-each-ref --format='%(refname:short)' refs/remotes
+          docker pull ghcr.io/linuxserver/yq
+          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
+          do
+            br=$(echo "$br" | sed 's|origin/||g')
+            echo "evaluating branch ${br}"
+            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/jenkins-vars.yml \
+              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
+            if [ "$br" == "$ls_branch" ]; then
+              echo "it's a match, checking workflow"
+              if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/.github/workflows/external_trigger.yml > /dev/null 2>&1; then
+                echo "workflow exists, triggering"
+                curl -iX POST \
+                  -H "Authorization: token ${{ secrets.CR_PAT }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -d "{\"ref\":\"refs/heads/${br}\"}" \
+                  https://api.github.com/repos/linuxserver/docker-jenkins-builder/actions/workflows/external_trigger.yml/dispatches
+              else
+                echo "workflow doesn't exist, skipping"
+              fi
+            else
+              echo "no match, skipping"
+            fi
+          done

--- a/.github/workflows/external_trigger_scheduler.yml
+++ b/.github/workflows/external_trigger_scheduler.yml
@@ -2,7 +2,7 @@ name: External Trigger Scheduler
 
 on:
   schedule:
-    - cron:  '02 * * * *'
+    - cron:  '10 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/package_trigger.yml
+++ b/.github/workflows/package_trigger.yml
@@ -20,16 +20,19 @@ jobs:
           for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
           do
             br=$(echo "$br" | sed 's|origin/||g')
-            echo "evaluating branch ${br}"
+            echo "Evaluating branch ${br}"
             ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/jenkins-vars.yml \
               | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
-            if [ "$br" == "$ls_branch" ]; then
-              echo "it's a match, triggering build for ${br}"
+            pause_trigger="$(eval echo \${pause_package_trigger_jenkins-builder_$ls_branch})"
+            if [ "${br}" == "${ls_branch}" ] && [ -z "${pause_triger}" ]; then
+              echo "${br} is a live branch; triggering package build (you can pause this trigger by setting a github secret \"pause_package_trigger_jenkins-builder_${ls_branch}\")."
               curl -X POST \
                 https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jenkins-builder/job/${br}/buildWithParameters?PACKAGE_CHECK=true \
                 --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}
               sleep 30
+            elif [ "${br}" == "${ls_branch}" ] && [ -n "${pause_triger}" ]; then
+              echo "Github secret \"pause_package_trigger_jenkins-builder_${ls_branch}\" is set; skipping trigger."
             else
-              echo "no match, skipping branch ${br}"
+              echo "${br} appears to be a dev branch; skipping."
             fi
           done

--- a/.github/workflows/package_trigger.yml
+++ b/.github/workflows/package_trigger.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Package Trigger
+        if: github.ref == 'refs/heads/master'
         run: |
           curl -X POST \
             https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jenkins-builder/job/master/buildWithParameters?PACKAGE_CHECK=true \

--- a/.github/workflows/package_trigger.yml
+++ b/.github/workflows/package_trigger.yml
@@ -1,38 +1,22 @@
-name: Package Trigger
+name: Package Trigger Main
 
 on:
-  schedule:
-    - cron:  '04 0 * * 0'
   workflow_dispatch:
 
 jobs:
-  package-trigger:
+  package-trigger-master:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.3
-        with:
-          fetch-depth: '0'
-        
+
       - name: Package Trigger
+        if: github.ref == 'refs/heads/master'
         run: |
-          git for-each-ref --format='%(refname:short)' refs/remotes
-          docker pull ghcr.io/linuxserver/yq
-          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
-          do
-            br=$(echo "$br" | sed 's|origin/||g')
-            echo "Evaluating branch ${br}"
-            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/jenkins-vars.yml \
-              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
-            pause_trigger="$(eval echo \${pause_package_trigger_jenkins-builder_$ls_branch})"
-            if [ "${br}" == "${ls_branch}" ] && [ -z "${pause_triger}" ]; then
-              echo "${br} is a live branch; triggering package build (you can pause this trigger by setting a github secret \"pause_package_trigger_jenkins-builder_${ls_branch}\")."
-              curl -X POST \
-                https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jenkins-builder/job/${br}/buildWithParameters?PACKAGE_CHECK=true \
-                --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}
-              sleep 30
-            elif [ "${br}" == "${ls_branch}" ] && [ -n "${pause_triger}" ]; then
-              echo "Github secret \"pause_package_trigger_jenkins-builder_${ls_branch}\" is set; skipping trigger."
-            else
-              echo "${br} appears to be a dev branch; skipping."
-            fi
-          done
+          if [ -n ${{ secrets.PAUSE_PACKAGE_TRIGGER_JENKINS_BUILDER_MASTER }} ]; then
+            echo "Github secret PAUSE_PACKAGE_TRIGGER_JENKINS_BUILDER_MASTER is set; skipping trigger."
+            exit 0
+          fi
+          echo "Package trigger running off of master branch. To disable, set a Github secret named \"PAUSE_PACKAGE_TRIGGER_JENKINS_BUILDER_MASTER\"."
+          curl -X POST \
+            https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jenkins-builder/job/master/buildWithParameters?PACKAGE_CHECK=true \
+            --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}

--- a/.github/workflows/package_trigger.yml
+++ b/.github/workflows/package_trigger.yml
@@ -1,0 +1,15 @@
+name: Package Trigger
+
+on:
+  schedule:
+    - cron:  '04 0 * * 0'
+
+jobs:
+  package-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Package Trigger
+        run: |
+          curl -X POST \
+            https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jenkins-builder/job/master/buildWithParameters?PACKAGE_CHECK=true \
+            --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}

--- a/.github/workflows/package_trigger.yml
+++ b/.github/workflows/package_trigger.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Package Trigger
         if: github.ref == 'refs/heads/master'
         run: |
-          if [ -n ${{ secrets.PAUSE_PACKAGE_TRIGGER_JENKINS_BUILDER_MASTER }} ]; then
+          if [ -n "${{ secrets.PAUSE_PACKAGE_TRIGGER_JENKINS_BUILDER_MASTER }}" ]; then
             echo "Github secret PAUSE_PACKAGE_TRIGGER_JENKINS_BUILDER_MASTER is set; skipping trigger."
             exit 0
           fi

--- a/.github/workflows/package_trigger.yml
+++ b/.github/workflows/package_trigger.yml
@@ -3,14 +3,33 @@ name: Package Trigger
 on:
   schedule:
     - cron:  '04 0 * * 0'
+  workflow_dispatch:
 
 jobs:
   package-trigger:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: '0'
+        
       - name: Package Trigger
-        if: github.ref == 'refs/heads/master'
         run: |
-          curl -X POST \
-            https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jenkins-builder/job/master/buildWithParameters?PACKAGE_CHECK=true \
-            --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}
+          git for-each-ref --format='%(refname:short)' refs/remotes
+          docker pull ghcr.io/linuxserver/yq
+          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
+          do
+            br=$(echo "$br" | sed 's|origin/||g')
+            echo "evaluating branch ${br}"
+            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/jenkins-vars.yml \
+              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
+            if [ "$br" == "$ls_branch" ]; then
+              echo "it's a match, triggering build for ${br}"
+              curl -X POST \
+                https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-jenkins-builder/job/${br}/buildWithParameters?PACKAGE_CHECK=true \
+                --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }}
+              sleep 30
+            else
+              echo "no match, skipping branch ${br}"
+            fi
+          done

--- a/.github/workflows/package_trigger_scheduler.yml
+++ b/.github/workflows/package_trigger_scheduler.yml
@@ -2,7 +2,7 @@ name: Package Trigger Scheduler
 
 on:
   schedule:
-    - cron:  '04 0 * * 0'
+    - cron:  '55 0 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/package_trigger_scheduler.yml
+++ b/.github/workflows/package_trigger_scheduler.yml
@@ -1,19 +1,19 @@
-name: External Trigger Scheduler
+name: Package Trigger Scheduler
 
 on:
   schedule:
-    - cron:  '02 * * * *'
+    - cron:  '04 0 * * 0'
   workflow_dispatch:
 
 jobs:
-  external-trigger-scheduler:
+  package-trigger-scheduler:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.3
         with:
           fetch-depth: '0'
         
-      - name: External Trigger Scheduler
+      - name: Package Trigger Scheduler
         run: |
           git for-each-ref --format='%(refname:short)' refs/remotes
           docker pull ghcr.io/linuxserver/yq
@@ -23,15 +23,16 @@ jobs:
             echo "Evaluating branch ${br}"
             ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/jenkins-vars.yml \
               | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
-            if [ "$br" == "$ls_branch" ]; then
-              echo "${br} is a live branch, checking workflow."
-              if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/.github/workflows/external_trigger.yml > /dev/null 2>&1; then
-                echo "Workflow exists. Triggering external trigger workflow for branch ${br}."
+            if [ "${br}" == "${ls_branch}" ]; then
+              echo "Branch ${br} appears to be live; triggering."
+              if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/${br}/.github/workflows/package_trigger.yml > /dev/null 2>&1; then
+                echo "Workflow exists. Triggering package trigger workflow for branch ${br}."
                 curl -iX POST \
                   -H "Authorization: token ${{ secrets.CR_PAT }}" \
                   -H "Accept: application/vnd.github.v3+json" \
                   -d "{\"ref\":\"refs/heads/${br}\"}" \
-                  https://api.github.com/repos/linuxserver/docker-jenkins-builder/actions/workflows/external_trigger.yml/dispatches
+                  https://api.github.com/repos/linuxserver/docker-jenkins-builder/actions/workflows/package_trigger.yml/dispatches
+                sleep 30
               else
                 echo "Workflow doesn't exist; skipping trigger."
               fi

--- a/.github/workflows/package_trigger_scheduler.yml
+++ b/.github/workflows/package_trigger_scheduler.yml
@@ -2,7 +2,7 @@ name: Package Trigger Scheduler
 
 on:
   schedule:
-    - cron:  '55 0 * * 0'
+    - cron:  '55 5 * * 5'
   workflow_dispatch:
 
 jobs:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml ./.github/workflows/package_trigger.yml'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml ./.github/workflows/package_trigger.yml ./.github/workflows/external_trigger.yml ./.github/workflows/external_trigger_scheduler.yml'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml ./.github/workflows/package_trigger.yml ./.github/workflows/external_trigger.yml ./.github/workflows/external_trigger_scheduler.yml'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml ./.github/workflows/package_trigger.yml ./.github/workflows/package_trigger_scheduler.yml ./.github/workflows/external_trigger.yml ./.github/workflows/external_trigger_scheduler.yml'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml ./.github/workflows/package_trigger.yml'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/roles/generate-jenkins/defaults/main.yml
+++ b/roles/generate-jenkins/defaults/main.yml
@@ -43,3 +43,5 @@ nginx_reverse_proxy_snippet_enabled: false
 nginx_reverse_proxy_block: ""
 optional_block_1: false
 changelogs: []
+custom_external_trigger: ""
+custom_package_trigger: ""

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -32,7 +32,7 @@
     file: "/tmp/{{ item }}"
   loop: "{{  templated_vars  }}"
 
-- name: Inlcude template loop variables
+- name: include template loop variables
   include_vars:
     file: "/ansible/roles/generate-jenkins/templates.yml"
 
@@ -116,9 +116,7 @@
     - item.readme is not defined
     - item.donate is not defined
     - item.package_trigger is not defined
-    - item.package_trigger_scheduler is not defined
     - item.external_trigger is not defined
-    - item.external_trigger_scheduler is not defined
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -133,9 +131,7 @@
     - item.readme is not defined
     - item.donate is not defined
     - item.package_trigger is not defined
-    - item.package_trigger_scheduler is not defined
     - item.external_trigger is not defined
-    - item.external_trigger_scheduler is not defined
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"
@@ -254,34 +250,6 @@
   delegate_to: localhost
   loop: "{{  templated_files  }}"
 
-# Package trigger scheduler templating
-
-- name: write package trigger scheduler
-  when:
-    - lookup('env', 'LOCAL') != "true"
-    - item.package_trigger_scheduler is defined
-    - ls_branch == 'master' or ls_branch == 'main'
-  template:
-    src: "../templates/{{ item.src }}"
-    dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
-    owner: "abc"
-    group: "abc"
-  delegate_to: localhost
-  loop: "{{  templated_files  }}"
-
-- name: write package trigger scheduler local
-  when:
-    - lookup('env', 'LOCAL') == "true"
-    - item.package_trigger_scheduler is defined
-    - ls_branch == 'master' or ls_branch == 'main'
-  template:
-    src: "../templates/{{ item.src }}"
-    dest: "/tmp/{{ item.dest }}"
-    owner: "abc"
-    group: "abc"
-  delegate_to: localhost
-  loop: "{{  templated_files  }}"
-
 # External trigger templating
 
 - name: write external trigger
@@ -302,34 +270,6 @@
     - lookup('env', 'LOCAL') == "true"
     - item.external_trigger is defined
     - custom_external_trigger != true
-  template:
-    src: "../templates/{{ item.src }}"
-    dest: "/tmp/{{ item.dest }}"
-    owner: "abc"
-    group: "abc"
-  delegate_to: localhost
-  loop: "{{  templated_files  }}"
-
-# External trigger scheduler templating
-
-- name: write external trigger scheduler
-  when:
-    - lookup('env', 'LOCAL') != "true"
-    - item.external_trigger_scheduler is defined
-    - ls_branch == 'master' or ls_branch == 'main'
-  template:
-    src: "../templates/{{ item.src }}"
-    dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
-    owner: "abc"
-    group: "abc"
-  delegate_to: localhost
-  loop: "{{  templated_files  }}"
-
-- name: write external trigger scheduler local
-  when:
-    - lookup('env', 'LOCAL') == "true"
-    - item.external_trigger_scheduler is defined
-    - ls_branch == 'master' or ls_branch == 'main'
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -116,6 +116,7 @@
     - item.readme is not defined
     - item.donate is not defined
     - item.package_trigger is not defined
+    - item.package_trigger_scheduler is not defined
     - item.external_trigger is not defined
     - item.external_trigger_scheduler is not defined
   template:
@@ -132,6 +133,7 @@
     - item.readme is not defined
     - item.donate is not defined
     - item.package_trigger is not defined
+    - item.package_trigger_scheduler is not defined
     - item.external_trigger is not defined
     - item.external_trigger_scheduler is not defined
   template:

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -225,7 +225,7 @@
 - name: write package trigger
   when:
     - lookup('env', 'LOCAL') != "true"
-    - item.package is defined
+    - item.package_trigger is defined
     - custom_package_trigger is not defined
     - ls_branch == 'master' or ls_branch == 'main'
   template:
@@ -239,8 +239,64 @@
 - name: write package trigger local
   when:
     - lookup('env', 'LOCAL') == "true"
-    - item.package is defined
+    - item.package_trigger is defined
     - custom_package_trigger is not defined
+    - ls_branch == 'master' or ls_branch == 'main'
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "/tmp/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+# External trigger templating
+
+- name: write external trigger
+  when:
+    - lookup('env', 'LOCAL') != "true"
+    - item.external_trigger is defined
+    - custom_external_trigger is not defined
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+- name: write external trigger local
+  when:
+    - lookup('env', 'LOCAL') == "true"
+    - item.external_trigger is defined
+    - custom_external_trigger is not defined
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "/tmp/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+# External trigger scheduler templating
+
+- name: write external trigger scheduler
+  when:
+    - lookup('env', 'LOCAL') != "true"
+    - item.external_trigger_scheduler is defined
+    - ls_branch == 'master' or ls_branch == 'main'
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+- name: write external trigger scheduler local
+  when:
+    - lookup('env', 'LOCAL') == "true"
+    - item.external_trigger_scheduler is defined
     - ls_branch == 'master' or ls_branch == 'main'
   template:
     src: "../templates/{{ item.src }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -259,7 +259,7 @@
 - name: write package trigger scheduler
   when:
     - lookup('env', 'LOCAL') != "true"
-    - item.package_trigger is defined
+    - item.package_trigger_scheduler is defined
     - ls_branch == 'master' or ls_branch == 'main'
   template:
     src: "../templates/{{ item.src }}"
@@ -272,7 +272,7 @@
 - name: write package trigger scheduler local
   when:
     - lookup('env', 'LOCAL') == "true"
-    - item.package_trigger is defined
+    - item.package_trigger_scheduler is defined
     - ls_branch == 'master' or ls_branch == 'main'
   template:
     src: "../templates/{{ item.src }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -230,8 +230,7 @@
   when:
     - lookup('env', 'LOCAL') != "true"
     - item.package_trigger is defined
-    - custom_package_trigger is not defined
-    - ls_branch == 'master' or ls_branch == 'main'
+    - custom_package_trigger != "true"
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -244,7 +243,34 @@
   when:
     - lookup('env', 'LOCAL') == "true"
     - item.package_trigger is defined
-    - custom_package_trigger is not defined
+    - custom_package_trigger != "true"
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "/tmp/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+# Package trigger scheduler templating
+
+- name: write package trigger scheduler
+  when:
+    - lookup('env', 'LOCAL') != "true"
+    - item.package_trigger is defined
+    - ls_branch == 'master' or ls_branch == 'main'
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+- name: write package trigger scheduler local
+  when:
+    - lookup('env', 'LOCAL') == "true"
+    - item.package_trigger is defined
     - ls_branch == 'master' or ls_branch == 'main'
   template:
     src: "../templates/{{ item.src }}"
@@ -260,7 +286,7 @@
   when:
     - lookup('env', 'LOCAL') != "true"
     - item.external_trigger is defined
-    - custom_external_trigger is not defined
+    - custom_external_trigger != "true"
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -273,7 +299,7 @@
   when:
     - lookup('env', 'LOCAL') == "true"
     - item.external_trigger is defined
-    - custom_external_trigger is not defined
+    - custom_external_trigger != "true"
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -115,6 +115,7 @@
     - lookup('env', 'LOCAL') != "true"
     - item.readme is not defined
     - item.donate is not defined
+    - item.package is not defined
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -128,6 +129,7 @@
     - lookup('env', 'LOCAL') == "true"
     - item.readme is not defined
     - item.donate is not defined
+    - item.package is not defined
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"
@@ -210,6 +212,34 @@
     - lookup('env', 'LOCAL') == "true"
     - item.donate is defined
     - sponsor_links is defined
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "/tmp/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+# Package trigger templating
+
+- name: write package trigger
+  when:
+    - lookup('env', 'LOCAL') != "true"
+    - item.package is defined
+    - custom_package_trigger is not defined
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+- name: write package trigger local
+  when:
+    - lookup('env', 'LOCAL') == "true"
+    - item.package is defined
+    - custom_package_trigger is not defined
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -227,6 +227,7 @@
     - lookup('env', 'LOCAL') != "true"
     - item.package is defined
     - custom_package_trigger is not defined
+    - ls_branch == 'master' or ls_branch == 'main'
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -240,6 +241,7 @@
     - lookup('env', 'LOCAL') == "true"
     - item.package is defined
     - custom_package_trigger is not defined
+    - ls_branch == 'master' or ls_branch == 'main'
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -232,7 +232,7 @@
   when:
     - lookup('env', 'LOCAL') != "true"
     - item.package_trigger is defined
-    - custom_package_trigger != "true"
+    - custom_package_trigger != true
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -245,7 +245,7 @@
   when:
     - lookup('env', 'LOCAL') == "true"
     - item.package_trigger is defined
-    - custom_package_trigger != "true"
+    - custom_package_trigger != true
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"
@@ -288,7 +288,7 @@
   when:
     - lookup('env', 'LOCAL') != "true"
     - item.external_trigger is defined
-    - custom_external_trigger != "true"
+    - custom_external_trigger != true
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -301,7 +301,7 @@
   when:
     - lookup('env', 'LOCAL') == "true"
     - item.external_trigger is defined
-    - custom_external_trigger != "true"
+    - custom_external_trigger != true
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -115,7 +115,9 @@
     - lookup('env', 'LOCAL') != "true"
     - item.readme is not defined
     - item.donate is not defined
-    - item.package is not defined
+    - item.package_trigger is not defined
+    - item.external_trigger is not defined
+    - item.external_trigger_scheduler is not defined
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -129,7 +131,9 @@
     - lookup('env', 'LOCAL') == "true"
     - item.readme is not defined
     - item.donate is not defined
-    - item.package is not defined
+    - item.package_trigger is not defined
+    - item.external_trigger is not defined
+    - item.external_trigger_scheduler is not defined
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"

--- a/roles/generate-jenkins/templates.yml
+++ b/roles/generate-jenkins/templates.yml
@@ -13,4 +13,6 @@ templated_files:
  - { src: 'greetings.j2', dest: '.github/workflows/greetings.yml' }
  - { src: 'stale.j2', dest: '.github/workflows/stale.yml' }
  - { src: 'CONTRIBUTING.j2', dest: '.github/CONTRIBUTING.md' }
- - { src: 'PACKAGE_TRIGGER.j2', dest: '.github/workflows/package_trigger.yml', package: 'true' }
+ - { src: 'PACKAGE_TRIGGER.j2', dest: '.github/workflows/package_trigger.yml', package_trigger: 'true' }
+ - { src: 'EXTERNAL_TRIGGER.j2', dest: '.github/workflows/external_trigger.yml', external_trigger: 'true' }
+ - { src: 'EXTERNAL_TRIGGER_SCHEDULER.j2', dest: '.github/workflows/external_trigger_scheduler.yml', external_trigger_scheduler: 'true' }

--- a/roles/generate-jenkins/templates.yml
+++ b/roles/generate-jenkins/templates.yml
@@ -14,5 +14,6 @@ templated_files:
  - { src: 'stale.j2', dest: '.github/workflows/stale.yml' }
  - { src: 'CONTRIBUTING.j2', dest: '.github/CONTRIBUTING.md' }
  - { src: 'PACKAGE_TRIGGER.j2', dest: '.github/workflows/package_trigger.yml', package_trigger: 'true' }
+ - { src: 'PACKAGE_TRIGGER_SCHEDULER.j2', dest: '.github/workflows/package_trigger_scheduler.yml', package_trigger_scheduler: 'true' }
  - { src: 'EXTERNAL_TRIGGER.j2', dest: '.github/workflows/external_trigger.yml', external_trigger: 'true' }
  - { src: 'EXTERNAL_TRIGGER_SCHEDULER.j2', dest: '.github/workflows/external_trigger_scheduler.yml', external_trigger_scheduler: 'true' }

--- a/roles/generate-jenkins/templates.yml
+++ b/roles/generate-jenkins/templates.yml
@@ -13,3 +13,4 @@ templated_files:
  - { src: 'greetings.j2', dest: '.github/workflows/greetings.yml' }
  - { src: 'stale.j2', dest: '.github/workflows/stale.yml' }
  - { src: 'CONTRIBUTING.j2', dest: '.github/CONTRIBUTING.md' }
+ - { src: 'PACKAGE_TRIGGER.j2', dest: '.github/workflows/package_trigger.yml', package: 'true' }

--- a/roles/generate-jenkins/templates.yml
+++ b/roles/generate-jenkins/templates.yml
@@ -14,6 +14,6 @@ templated_files:
  - { src: 'stale.j2', dest: '.github/workflows/stale.yml' }
  - { src: 'CONTRIBUTING.j2', dest: '.github/CONTRIBUTING.md' }
  - { src: 'PACKAGE_TRIGGER.j2', dest: '.github/workflows/package_trigger.yml', package_trigger: 'true' }
- - { src: 'PACKAGE_TRIGGER_SCHEDULER.j2', dest: '.github/workflows/package_trigger_scheduler.yml', package_trigger_scheduler: 'true' }
+ - { src: 'PACKAGE_TRIGGER_SCHEDULER.j2', dest: '.github/workflows/package_trigger_scheduler.yml' }
  - { src: 'EXTERNAL_TRIGGER.j2', dest: '.github/workflows/external_trigger.yml', external_trigger: 'true' }
- - { src: 'EXTERNAL_TRIGGER_SCHEDULER.j2', dest: '.github/workflows/external_trigger_scheduler.yml', external_trigger_scheduler: 'true' }
+ - { src: 'EXTERNAL_TRIGGER_SCHEDULER.j2', dest: '.github/workflows/external_trigger_scheduler.yml' }

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -7,6 +7,103 @@ jobs:
   external-trigger-{{ ls_branch }}:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2.3.3
+
       - name: External Trigger
+        if: github.ref == 'refs/heads/{{ ls_branch }}'
         run: |
           echo "external trigger running off of {{ ls_branch }} branch"
+          echo "setting env vars"
+{% for repo_var in repo_vars %}
+          {{ repo_var|regex_replace('\s(?==)','')|regex_replace('(?<==)\s','') }}
+{% endfor %}
+          echo "retrieving external version"
+{% if custom_version_command is defined %}
+          EXT_RELEASE=$({{ custom_version_command }})
+{% endif %}
+{% if external_type == "github_devel" %}
+          EXT_RELEASE=$(curl -s "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases" | jq -r '.[0] | .tag_name')
+{% elif external_type == "github_stable" %}
+          EXT_RELEASE=$(curl -s "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest" | jq -r '. | .tag_name')
+{% elif external_type == "alpine_repo" %}
+          EXT_RELEASE=$(docker run --rm alpine:${DIST_TAG} sh -c 'apk update --quiet --repository '"${DIST_REPO}"'\
+            && apk info --repository '"${DIST_REPO}"' '"${DIST_REPO_PACKAGES}"' | md5sum | cut -c1-8')
+{% elif external_type == "custom_json" %}
+          EXT_RELEASE=$(curl -s "${JSON_URL}" | jq -r ". | ${JSON_PATH}")
+{% elif external_type == "deb_repo" %}
+          EXT_RELEASE=$(docker run --rm "${DIST_IMAGE}":"${DIST_TAG}" bash -c \
+            'echo -e "'"${DIST_REPO}"'" > /etc/apt/sources.list.d/check.list \
+            && apt-get --allow-unauthenticated update -qq >/dev/null 2>&1\
+            && apt-cache --no-all-versions show '"${DIST_REPO_PACKAGES}"' | md5sum | cut -c1-8')
+{% elif external_type == "external_blob" %}
+          EXT_RELEASE=$(#! /bin/bash
+            if [ $(curl -I -sL -w "%{http_code}" "${EXT_BLOB}" -o /dev/null) == 200 ]; then
+              curl -s -L "${EXT_BLOB}" | md5sum | cut -c1-8
+            else
+              exit 1
+            fi)
+{% elif external_type == "github_commit" %}
+          EXT_RELEASE=$(curl -s "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/commits/${EXT_GIT_BRANCH}" | jq -r '. | .sha' | cut -c1-8)
+{% elif external_type == "gitlab_commit" %}
+          EXT_RELEASE=$(curl -s "https://gitlab.com/api/v4/projects/${EXT_GITLAB_ID}/repository/commits/${EXT_GIT_BRANCH}" | jq -r '. | .id' | cut -c1-8)
+{% elif external_type == "npm_version" %}
+          EXT_RELEASE=$(curl -sL "https://replicate.npmjs.com/registry/${EXT_NPM}" |jq -r '. | .["dist-tags"].latest')
+{% elif external_type == "pip_version" %}
+          EXT_RELEASE=$(curl -sL "https://pypi.python.org/pypi/${EXT_PIP}/json" |jq -r '. | .info.version')
+{% elif external_type == "os" %}
+          echo "No external release, exiting."
+          exit 0
+{% endif %}
+{% if custom_version_command is defined or external_type != "os" %}
+          if [-z "${EXT_RELEASE}" ]; then
+            echo "Can't retrieve external version, exiting"
+            FAILURE_REASON="Can't retrieve external version for {{ project_name }} branch {{ ls_branch }}"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 16711680,
+              "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
+              "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
+            exit 1
+          fi
+          echo "retrieving last pushed version"
+          image="${LS_USER}/{{ project_name }}"
+{% if release_type == 'stable' %}
+          tag="latest"
+{% elif release_type == 'prerelease' %}
+          tag="{{ release_tag }}"
+{% endif %}
+          token=$(curl -s \
+            "https://auth.docker.io/token?scope=repository:${image}:pull&service=registry.docker.io" \
+            | jq -r '.token')
+          digest=$(curl -s \
+            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            --header "Authorization: Bearer ${token}" \
+            "https://registry-1.docker.io/v2/${image}/manifests/${tag}" \
+            | jq -r '.config.digest')
+          image_info=$(curl -sL \
+            --header "Authorization: Bearer ${token}" \
+            "https://registry-1.docker.io/v2/${image}/blobs/${digest}" \
+            | jq -r '.container_config')
+          IMAGE_RELEASE=$(echo ${image_info} | jq -r '.Labels.build_version' | awk '{print $3}')
+          IMAGE_VERSION=$(echo ${IMAGE_RELEASE} | awk -F'-ls' '{print $1}')
+          if [ -z "${IMAGE_VERSION}" ]; then
+            echo "Can't retrieve last pushed version, exiting"
+            FAILURE_REASON="Can't retrieve last pushed version for {{ project_name }} tag {{ release_tag }}"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 16711680,
+              "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
+              "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
+            exit 1
+          fi
+          if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
+            echo "Version ${EXT_RELEASE} already pushed, exiting"
+            exit 0
+          else
+            echo "New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build"
+            curl -X POST \
+              https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=false \
+              --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }}
+            echo "Notifying Discord"
+            TRIGGER_REASON="A version change was detected for {{ project_name }} tag {{ release_tag }}. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE}"
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+              "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n"}],
+              "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
+          fi
+{% endif %}

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -55,7 +55,7 @@ jobs:
           exit 0
 {% endif %}
 {% if custom_version_command is defined or external_type != "os" %}
-          if [-z "${EXT_RELEASE}" ]; then
+          if [ -z "${EXT_RELEASE}" ]; then
             echo "Can't retrieve external version, exiting"
             FAILURE_REASON="Can't retrieve external version for {{ project_name }} branch {{ ls_branch }}"
             curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 16711680,

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -26,9 +26,9 @@ jobs:
           EXT_RELEASE=$({{ custom_version_command }})
 {% endif %}
 {% if external_type == "github_devel" %}
-          EXT_RELEASE=$(curl -s "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases" | jq -r '.[0] | .tag_name')
+          EXT_RELEASE=$(curl -u "${{ '{{' }} secrets.CR_USER {{ '}}' }}:${{ '{{' }} secrets.CR_PAT {{ '}}' }}" -sX GET "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases" | jq -r '.[0] | .tag_name')
 {% elif external_type == "github_stable" %}
-          EXT_RELEASE=$(curl -s "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest" | jq -r '. | .tag_name')
+          EXT_RELEASE=$(curl -u "${{ '{{' }} secrets.CR_USER {{ '}}' }}:${{ '{{' }} secrets.CR_PAT {{ '}}' }}" -sX GET "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/releases/latest" | jq -r '. | .tag_name')
 {% elif external_type == "alpine_repo" %}
           EXT_RELEASE=$(docker run --rm alpine:${DIST_TAG} sh -c 'apk update --quiet --repository '"${DIST_REPO}"'\
             && apk info --repository '"${DIST_REPO}"' '"${DIST_REPO_PACKAGES}"' | md5sum | cut -c1-8')
@@ -47,7 +47,7 @@ jobs:
               exit 1
             fi)
 {% elif external_type == "github_commit" %}
-          EXT_RELEASE=$(curl -s "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/commits/${EXT_GIT_BRANCH}" | jq -r '. | .sha' | cut -c1-8)
+          EXT_RELEASE=$(curl -u "${{ '{{' }} secrets.CR_USER {{ '}}' }}:${{ '{{' }} secrets.CR_PAT {{ '}}' }}" -sX GET "https://api.github.com/repos/${EXT_USER}/${EXT_REPO}/commits/${EXT_GIT_BRANCH}" | jq -r '. | .sha' | cut -c1-8)
 {% elif external_type == "gitlab_commit" %}
           EXT_RELEASE=$(curl -s "https://gitlab.com/api/v4/projects/${EXT_GITLAB_ID}/repository/commits/${EXT_GIT_BRANCH}" | jq -r '. | .id' | cut -c1-8)
 {% elif external_type == "npm_version" %}

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -65,11 +65,7 @@ jobs:
           fi
           echo "retrieving last pushed version"
           image="${LS_USER}/{{ project_name }}"
-{% if release_type == 'stable' %}
-          tag="latest"
-{% elif release_type == 'prerelease' %}
           tag="{{ release_tag }}"
-{% endif %}
           token=$(curl -s \
             "https://auth.docker.io/token?scope=repository:${image}:pull&service=registry.docker.io" \
             | jq -r '.token')

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -1,0 +1,12 @@
+name: External Trigger Main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  external-trigger-{{ ls_branch }}:
+    runs-on: ubuntu-latest
+    steps:
+      - name: External Trigger
+        run: |
+          echo "external trigger running off of {{ ls_branch }} branch"

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -12,12 +12,16 @@ jobs:
       - name: External Trigger
         if: github.ref == 'refs/heads/{{ ls_branch }}'
         run: |
-          echo "external trigger running off of {{ ls_branch }} branch"
-          echo "setting env vars"
+          if [ -n ${{ '{{' }} secrets.PAUSE_EXTERNAL_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} {{ '}}' }} ]; then
+            echo "Github secret PAUSE_EXTERNAL_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} is set; skipping trigger."
+            exit 0
+          fi
+          echo "External trigger running off of {{ ls_branch }} branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }}\"."
+          echo "Setting env vars"
 {% for repo_var in repo_vars %}
           {{ repo_var|regex_replace('\s(?==)','')|regex_replace('(?<==)\s','') }}
 {% endfor %}
-          echo "retrieving external version"
+          echo "Retrieving external version"
 {% if custom_version_command is defined %}
           EXT_RELEASE=$({{ custom_version_command }})
 {% endif %}
@@ -63,7 +67,8 @@ jobs:
               "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
             exit 1
           fi
-          echo "retrieving last pushed version"
+          echo "External version: ${EXT_RELEASE}"
+          echo "Retrieving last pushed version"
           image="${LS_USER}/{{ project_name }}"
           tag="{{ release_tag }}"
           token=$(curl -s \
@@ -88,6 +93,7 @@ jobs:
               "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
             exit 1
           fi
+          echo "Last pushed version: ${IMAGE_VERSION}"
           if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
             echo "Version ${EXT_RELEASE} already pushed, exiting"
             exit 0

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -12,7 +12,7 @@ jobs:
       - name: External Trigger
         if: github.ref == 'refs/heads/{{ ls_branch }}'
         run: |
-          if [ -n ${{ '{{' }} secrets.PAUSE_EXTERNAL_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} {{ '}}' }} ]; then
+          if [ -n "${{ '{{' }} secrets.PAUSE_EXTERNAL_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} {{ '}}' }}" ]; then
             echo "Github secret PAUSE_EXTERNAL_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} is set; skipping trigger."
             exit 0
           fi

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -33,7 +33,11 @@ jobs:
           EXT_RELEASE=$(docker run --rm alpine:${DIST_TAG} sh -c 'apk update --quiet --repository '"${DIST_REPO}"'\
             && apk info --repository '"${DIST_REPO}"' '"${DIST_REPO_PACKAGES}"' | md5sum | cut -c1-8')
 {% elif external_type == "custom_json" %}
-          EXT_RELEASE=$(curl -s "${JSON_URL}" | jq -r ". | ${JSON_PATH}")
+          if [[ "${JSON_URL}" == *"api.github.com"* ]]; then
+            EXT_RELEASE=$(curl -u "${{ '{{' }} secrets.CR_USER {{ '}}' }}:${{ '{{' }} secrets.CR_PAT {{ '}}' }}" -sX GET "${JSON_URL}" | jq -r ". | ${JSON_PATH}")
+          else
+            EXT_RELEASE=$(curl -s "${JSON_URL}" | jq -r ". | ${JSON_PATH}")
+          fi
 {% elif external_type == "deb_repo" %}
           EXT_RELEASE=$(docker run --rm "${DIST_IMAGE}":"${DIST_TAG}" bash -c \
             'echo -e "'"${DIST_REPO}"'" > /etc/apt/sources.list.d/check.list \
@@ -71,17 +75,30 @@ jobs:
           echo "Retrieving last pushed version"
           image="${LS_USER}/{{ project_name }}"
           tag="{{ release_tag }}"
-          token=$(curl -s \
-            "https://auth.docker.io/token?scope=repository:${image}:pull&service=registry.docker.io" \
+          token=$(curl -sX GET \
+            "https://ghcr.io/token?scope=repository%3A${LS_USER}%2F{{ project_name }}%3Apull" \
             | jq -r '.token')
-          digest=$(curl -s \
-            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-            --header "Authorization: Bearer ${token}" \
-            "https://registry-1.docker.io/v2/${image}/manifests/${tag}" \
-            | jq -r '.config.digest')
+          if [ "${MULTIARCH}" == "true" ]; then
+            multidigest=$(curl -s \
+              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              --header "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/${image}/manifests/${tag}" \
+              | jq -r 'first(.manifests[].digest)')
+            digest=$(curl -s \
+              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              --header "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/${image}/manifests/${multidigest}" \
+              | jq -r '.config.digest')
+          else
+            digest=$(curl -s \
+              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              --header "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/${image}/manifests/${tag}" \
+              | jq -r '.config.digest')
+          fi
           image_info=$(curl -sL \
             --header "Authorization: Bearer ${token}" \
-            "https://registry-1.docker.io/v2/${image}/blobs/${digest}" \
+            "https://ghcr.io/v2/${image}/blobs/${digest}" \
             | jq -r '.container_config')
           IMAGE_RELEASE=$(echo ${image_info} | jq -r '.Labels.build_version' | awk '{print $3}')
           IMAGE_VERSION=$(echo ${IMAGE_RELEASE} | awk -F'-ls' '{print $1}')

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
@@ -2,7 +2,7 @@ name: External Trigger Scheduler
 
 on:
   schedule:
-    - cron:  '{{ ('docker-' + project_name)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} * * * *'
+    - cron:  '{{ ('docker-' + project_name + '-external')|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} * * * *'
   workflow_dispatch:
 
 jobs:

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
@@ -24,18 +24,24 @@ jobs:
             ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/jenkins-vars.yml \
               | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
             if [ "$br" == "$ls_branch" ]; then
-              echo "it's a match, checking workflow"
+              echo "${br} is a live branch, checking workflow."
               if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/.github/workflows/external_trigger.yml > /dev/null 2>&1; then
-                echo "workflow exists, triggering"
-                curl -iX POST \
-                  -H "Authorization: token ${{ '{{' }} secrets.CR_PAT {{ '}}' }}" \
-                  -H "Accept: application/vnd.github.v3+json" \
-                  -d "{\"ref\":\"refs/heads/${br}\"}" \
-                  https://api.github.com/repos/linuxserver/docker-{{ project_name }}/actions/workflows/external_trigger.yml/dispatches
+                echo "Workflow exists."
+                pause_trigger="$(eval echo \${pause_external_trigger_{{ project_name }}_$ls_branch})"
+                if [ -z "$pause_trigger" ]; then
+                  echo "Triggering external build for branch ${br} (you can pause this trigger by setting a github secret \"pause_external_trigger_{{ project_name }}_${ls_branch}\")."
+                  curl -iX POST \
+                    -H "Authorization: token ${{ '{{' }} secrets.CR_PAT {{ '}}' }}" \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    -d "{\"ref\":\"refs/heads/${br}\"}" \
+                    https://api.github.com/repos/linuxserver/docker-{{ project_name }}/actions/workflows/external_trigger.yml/dispatches
+                else
+                  echo "Github secret \"pause_external_trigger_{{ project_name }}_${ls_branch}\" is set; skipping trigger."
+                fi
               else
-                echo "workflow doesn't exist, skipping"
+                echo "Workflow doesn't exist; skipping trigger."
               fi
             else
-              echo "no match, skipping"
+              echo "${br} appears to be a dev branch; skipping trigger."
             fi
           done

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
@@ -20,24 +20,18 @@ jobs:
           for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
           do
             br=$(echo "$br" | sed 's|origin/||g')
-            echo "evaluating branch ${br}"
+            echo "Evaluating branch ${br}"
             ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/jenkins-vars.yml \
               | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
             if [ "$br" == "$ls_branch" ]; then
               echo "${br} is a live branch, checking workflow."
               if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/.github/workflows/external_trigger.yml > /dev/null 2>&1; then
-                echo "Workflow exists."
-                pause_trigger="$(eval echo \${pause_external_trigger_{{ project_name }}_$ls_branch})"
-                if [ -z "$pause_trigger" ]; then
-                  echo "Triggering external build for branch ${br} (you can pause this trigger by setting a github secret \"pause_external_trigger_{{ project_name }}_${ls_branch}\")."
-                  curl -iX POST \
-                    -H "Authorization: token ${{ '{{' }} secrets.CR_PAT {{ '}}' }}" \
-                    -H "Accept: application/vnd.github.v3+json" \
-                    -d "{\"ref\":\"refs/heads/${br}\"}" \
-                    https://api.github.com/repos/linuxserver/docker-{{ project_name }}/actions/workflows/external_trigger.yml/dispatches
-                else
-                  echo "Github secret \"pause_external_trigger_{{ project_name }}_${ls_branch}\" is set; skipping trigger."
-                fi
+                echo "Workflow exists. Triggering external trigger workflow for branch ${br}."
+                curl -iX POST \
+                  -H "Authorization: token ${{ '{{' }} secrets.CR_PAT {{ '}}' }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -d "{\"ref\":\"refs/heads/${br}\"}" \
+                  https://api.github.com/repos/linuxserver/docker-{{ project_name }}/actions/workflows/external_trigger.yml/dispatches
               else
                 echo "Workflow doesn't exist; skipping trigger."
               fi

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
@@ -1,0 +1,41 @@
+name: External Trigger Scheduler
+
+on:
+  schedule:
+    - cron:  '{{ ('docker-' + project_name)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} * * * *'
+  workflow_dispatch:
+
+jobs:
+  external-trigger-scheduler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: '0'
+        
+      - name: External Trigger Scheduler
+        run: |
+          git for-each-ref --format='%(refname:short)' refs/remotes
+          docker pull ghcr.io/linuxserver/yq
+          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
+          do
+            br=$(echo "$br" | sed 's|origin/||g')
+            echo "evaluating branch ${br}"
+            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/jenkins-vars.yml \
+              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
+            if [ "$br" == "$ls_branch" ]; then
+              echo "it's a match, checking workflow"
+              if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/.github/workflows/external_trigger.yml > /dev/null 2>&1; then
+                echo "workflow exists, triggering"
+                curl -iX POST \
+                  -H "Authorization: token ${{ '{{' }} secrets.CR_PAT {{ '}}' }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -d "{\"ref\":\"refs/heads/${br}\"}" \
+                  https://api.github.com/repos/linuxserver/docker-{{ project_name }}/actions/workflows/external_trigger.yml/dispatches
+              else
+                echo "workflow doesn't exist, skipping"
+              fi
+            else
+              echo "no match, skipping"
+            fi
+          done

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -41,7 +41,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger != "true" %} ./.github/workflows/package_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/package_trigger_scheduler.yml{% endif %}{% if custom_external_trigger != "true" %} ./.github/workflows/external_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/external_trigger_scheduler.yml{% endif %}'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger != true %} ./.github/workflows/package_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/package_trigger_scheduler.yml{% endif %}{% if custom_external_trigger != true %} ./.github/workflows/external_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/external_trigger_scheduler.yml{% endif %}'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -41,7 +41,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger != true %} ./.github/workflows/package_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/package_trigger_scheduler.yml{% endif %}{% if custom_external_trigger != true %} ./.github/workflows/external_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/external_trigger_scheduler.yml{% endif %}'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger != true %} ./.github/workflows/package_trigger.yml{% endif %} ./.github/workflows/package_trigger_scheduler.yml{% if custom_external_trigger != true %} ./.github/workflows/external_trigger.yml{% endif %} ./.github/workflows/external_trigger_scheduler.yml'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -41,7 +41,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger is not defined %} ./.github/workflows/package_trigger.yml{% endif %}'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger is not defined %} ./.github/workflows/package_trigger.yml{% endif %}{% if custom_external_trigger is not defined %} ./.github/workflows/external_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/external_trigger_scheduler.yml{% endif %}'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -41,7 +41,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger is not defined %} ./.github/workflows/package_trigger.yml{% endif %}'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -41,7 +41,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger is not defined %} ./.github/workflows/package_trigger.yml{% endif %}{% if custom_external_trigger is not defined %} ./.github/workflows/external_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/external_trigger_scheduler.yml{% endif %}'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if custom_package_trigger != "true" %} ./.github/workflows/package_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/package_trigger_scheduler.yml{% endif %}{% if custom_external_trigger != "true" %} ./.github/workflows/external_trigger.yml{% endif %}{% if ls_branch == "master" or ls_branch == "main" %} ./.github/workflows/external_trigger_scheduler.yml{% endif %}'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
@@ -12,7 +12,7 @@ jobs:
       - name: Package Trigger
         if: github.ref == 'refs/heads/{{ ls_branch }}'
         run: |
-          if [ -n ${{ '{{' }} secrets.PAUSE_PACKAGE_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} {{ '}}' }} ]; then
+          if [ -n "${{ '{{' }} secrets.PAUSE_PACKAGE_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} {{ '}}' }}" ]; then
             echo "Github secret PAUSE_PACKAGE_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} is set; skipping trigger."
             exit 0
           fi

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
@@ -1,38 +1,22 @@
-name: Package Trigger
+name: Package Trigger Main
 
 on:
-  schedule:
-    - cron:  '{{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|truncate(1,True,'')|replace('a','10')|replace('b','11')|replace('c','12')|replace('d','13')|replace('e','14')|replace('f','15') }} * * {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(1,True,'')|replace('7','0')|replace('8','2')|replace('9','4') }}'
   workflow_dispatch:
 
 jobs:
-  package-trigger:
+  package-trigger-{{ ls_branch }}:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.3
-        with:
-          fetch-depth: '0'
-        
+
       - name: Package Trigger
+        if: github.ref == 'refs/heads/{{ ls_branch }}'
         run: |
-          git for-each-ref --format='%(refname:short)' refs/remotes
-          docker pull ghcr.io/linuxserver/yq
-          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
-          do
-            br=$(echo "$br" | sed 's|origin/||g')
-            echo "Evaluating branch ${br}"
-            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/jenkins-vars.yml \
-              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
-            pause_trigger="$(eval echo \${pause_package_trigger_{{ project_name }}_$ls_branch})"
-            if [ "${br}" == "${ls_branch}" ] && [ -z "${pause_triger}" ]; then
-              echo "${br} is a live branch; triggering package build (you can pause this trigger by setting a github secret \"pause_package_trigger_{{ project_name }}_${ls_branch}\")."
-              curl -X POST \
-                https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/${br}/buildWithParameters?PACKAGE_CHECK=true \
-                --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }}
-              sleep 30
-            elif [ "${br}" == "${ls_branch}" ] && [ -n "${pause_triger}" ]; then
-              echo "Github secret \"pause_package_trigger_{{ project_name }}_${ls_branch}\" is set; skipping trigger."
-            else
-              echo "${br} appears to be a dev branch; skipping."
-            fi
-          done
+          if [ -n ${{ '{{' }} secrets.PAUSE_PACKAGE_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} {{ '}}' }} ]; then
+            echo "Github secret PAUSE_PACKAGE_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }} is set; skipping trigger."
+            exit 0
+          fi
+          echo "Package trigger running off of {{ ls_branch }} branch. To disable, set a Github secret named \"PAUSE_PACKAGE_TRIGGER_{{ project_name|regex_replace('-','_')|upper }}_{{ ls_branch|regex_replace('-','_')|upper }}\"."
+          curl -X POST \
+            https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=true \
+            --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }}

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
@@ -20,16 +20,19 @@ jobs:
           for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
           do
             br=$(echo "$br" | sed 's|origin/||g')
-            echo "evaluating branch ${br}"
+            echo "Evaluating branch ${br}"
             ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/jenkins-vars.yml \
               | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
-            if [ "$br" == "$ls_branch" ]; then
-              echo "it's a match, triggering build for ${br}"
+            pause_trigger="$(eval echo \${pause_package_trigger_{{ project_name }}_$ls_branch})"
+            if [ "${br}" == "${ls_branch}" ] && [ -z "${pause_triger}" ]; then
+              echo "${br} is a live branch; triggering package build (you can pause this trigger by setting a github secret \"pause_package_trigger_{{ project_name }}_${ls_branch}\")."
               curl -X POST \
                 https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/${br}/buildWithParameters?PACKAGE_CHECK=true \
                 --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }}
               sleep 30
+            elif [ "${br}" == "${ls_branch}" ] && [ -n "${pause_triger}" ]; then
+              echo "Github secret \"pause_package_trigger_{{ project_name }}_${ls_branch}\" is set; skipping trigger."
             else
-              echo "no match, skipping branch ${br}"
+              echo "${br} appears to be a dev branch; skipping."
             fi
           done

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Package Trigger
+        if: github.ref == 'refs/heads/{{ ls_branch }}'
         run: |
           curl -X POST \
             https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=true \

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
@@ -3,14 +3,33 @@ name: Package Trigger
 on:
   schedule:
     - cron:  '{{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|truncate(1,True,'')|replace('a','10')|replace('b','11')|replace('c','12')|replace('d','13')|replace('e','14')|replace('f','15') }} * * {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(1,True,'')|replace('7','0')|replace('8','2')|replace('9','4') }}'
+  workflow_dispatch:
 
 jobs:
   package-trigger:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: '0'
+        
       - name: Package Trigger
-        if: github.ref == 'refs/heads/{{ ls_branch }}'
         run: |
-          curl -X POST \
-            https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=true \
-            --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }}
+          git for-each-ref --format='%(refname:short)' refs/remotes
+          docker pull ghcr.io/linuxserver/yq
+          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
+          do
+            br=$(echo "$br" | sed 's|origin/||g')
+            echo "evaluating branch ${br}"
+            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/jenkins-vars.yml \
+              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
+            if [ "$br" == "$ls_branch" ]; then
+              echo "it's a match, triggering build for ${br}"
+              curl -X POST \
+                https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/${br}/buildWithParameters?PACKAGE_CHECK=true \
+                --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }}
+              sleep 30
+            else
+              echo "no match, skipping branch ${br}"
+            fi
+          done

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
@@ -1,0 +1,15 @@
+name: Package Trigger
+
+on:
+  schedule:
+    - cron:  '{{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|truncate(1,True,'')|replace('a','10')|replace('b','11')|replace('c','12')|replace('d','13')|replace('e','14')|replace('f','15') }} * * {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(1,True,'')|replace('7','0')|replace('8','2')|replace('9','4') }}'
+
+jobs:
+  package-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Package Trigger
+        run: |
+          curl -X POST \
+            https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-{{ project_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=true \
+            --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }}

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
@@ -1,0 +1,42 @@
+name: Package Trigger Scheduler
+
+on:
+  schedule:
+    - cron:  '{{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|truncate(1,True,'')|replace('a','10')|replace('b','11')|replace('c','12')|replace('d','13')|replace('e','14')|replace('f','15') }} * * {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(1,True,'')|replace('7','0')|replace('8','2')|replace('9','4') }}'
+  workflow_dispatch:
+
+jobs:
+  package-trigger-scheduler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: '0'
+        
+      - name: Package Trigger Scheduler
+        run: |
+          git for-each-ref --format='%(refname:short)' refs/remotes
+          docker pull ghcr.io/linuxserver/yq
+          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
+          do
+            br=$(echo "$br" | sed 's|origin/||g')
+            echo "Evaluating branch ${br}"
+            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/jenkins-vars.yml \
+              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
+            if [ "${br}" == "${ls_branch}" ]; then
+              echo "Branch ${br} appears to be live; triggering."
+              if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-{{ project_name }}/${br}/.github/workflows/package_trigger.yml > /dev/null 2>&1; then
+                echo "Workflow exists. Triggering package trigger workflow for branch ${br}."
+                curl -iX POST \
+                  -H "Authorization: token ${{ '{{' }} secrets.CR_PAT {{ '}}' }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -d "{\"ref\":\"refs/heads/${br}\"}" \
+                  https://api.github.com/repos/linuxserver/docker-{{ project_name }}/actions/workflows/package_trigger.yml/dispatches
+                sleep 30
+              else
+                echo "Workflow doesn't exist; skipping trigger."
+              fi
+            else
+              echo "${br} appears to be a dev branch; skipping trigger."
+            fi
+          done

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
@@ -2,7 +2,7 @@ name: Package Trigger Scheduler
 
 on:
   schedule:
-    - cron:  '{{ ('docker-' + project_name + '-package')|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|truncate(1,True,'')|replace('a','10')|replace('b','11')|replace('c','12')|replace('d','13')|replace('e','14')|replace('f','15') }} * * {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(1,True,'')|replace('7','0')|replace('8','2')|replace('9','4') }}'
+    - cron:  '{{ ('docker-' + project_name + '-package')|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} {{ ('docker-' + project_name + '-package')|hash('sha512')|truncate(1,True,'')|replace('a','10')|replace('b','11')|replace('c','12')|replace('d','13')|replace('e','14')|replace('f','15') }} * * {{ ('docker-' + project_name + '-package')|hash('sha512')|regex_replace('[^0-9]+','')|truncate(1,True,'')|replace('7','0')|replace('8','2')|replace('9','4') }}'
   workflow_dispatch:
 
 jobs:

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
@@ -2,7 +2,7 @@ name: Package Trigger Scheduler
 
 on:
   schedule:
-    - cron:  '{{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|truncate(1,True,'')|replace('a','10')|replace('b','11')|replace('c','12')|replace('d','13')|replace('e','14')|replace('f','15') }} * * {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(1,True,'')|replace('7','0')|replace('8','2')|replace('9','4') }}'
+    - cron:  '{{ ('docker-' + project_name + '-package')|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|truncate(1,True,'')|replace('a','10')|replace('b','11')|replace('c','12')|replace('d','13')|replace('e','14')|replace('f','15') }} * * {{ ('docker-' + project_name + '/' + ls_branch)|hash('sha512')|regex_replace('[^0-9]+','')|truncate(1,True,'')|replace('7','0')|replace('8','2')|replace('9','4') }}'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Automated triggers based on jenkins-vars.yml, utilizing Github workflows
Schedulers run on cron, timers vary by repo (using hashes of repo names converted to timers), so they don't all run at the same time
Schedulers first check for live branches, existence of branch trigger workflows and github pause secrets, and then trigger the necessary workflows.