### PR TITLE
clean up arm baseimages on x86 builder

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -809,6 +809,22 @@ pipeline {
                 ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} || :
              '''
 {% endif %}
+{% if "docker-baseimage" in github_project_name %}
+          sh '''#! /bin/bash
+                for DELETEIMAGE in "${GITHUBIMAGE}" "${GITLABIMAGE}" "${IMAGE}"; do
+                  docker rmi \
+                  ${DELETEIMAGE}:arm32v7-${META_TAG} \
+                  ${DELETEIMAGE}:arm32v7-{{ release_tag }} \
+                  ${DELETEIMAGE}:arm32v7-${EXT_RELEASE_TAG} \
+                  ${DELETEIMAGE}:arm64v8-${META_TAG} \
+                  ${DELETEIMAGE}:arm64v8-{{ release_tag }} \
+                  ${DELETEIMAGE}:arm64v8-${EXT_RELEASE_TAG} || :
+                done
+                docker rmi \
+                ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} \
+                ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} || :
+             '''
+{% endif %}
         }
       }
     }


### PR DESCRIPTION
Currently, baseimage builds skip all clean up steps, which is the desired behavior for x86 images. However, armhf and aarch64 builds are also left behind.

This PR removes the armhf and aarch64 images from x86 builders after baseimage builds