### PR TITLE
Add unraid templating support, and minor fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,7 +258,7 @@ pipeline {
               fi
               mkdir -p ${TEMPDIR}/gitbook
               git clone https://github.com/linuxserver/docker-documentation.git ${TEMPDIR}/gitbook/docker-documentation
-              if [[ "${BRANCH_NAME}" == "master" ]] && [[ (! -f ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md) || ("$(md5sum ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')") ]]; then
+              if [[ ("${BRANCH_NAME}" == "master") || ("${BRANCH_NAME}" == "main") ]] && [[ (! -f ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md) || ("$(md5sum ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')") ]]; then
                 cp ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md ${TEMPDIR}/gitbook/docker-documentation/images/
                 cd ${TEMPDIR}/gitbook/docker-documentation/
                 git add images/docker-${CONTAINER_NAME}.md

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ docker run --rm \
   linuxserver/jenkins-builder:latest && \
 rm -f "$(basename $PWD).md" && \
 rm -f README.lite && \
-rm -f .github/ISSUE_TEMPLATE.md
+rm -f .github/ISSUE_TEMPLATE.md \
+rm -f "$(basename $PWD).xml"
 ```
 Newly generated files (including `README.md`, `Jenkinsfile`, issue templates, etc.) will overwrite the existing files in your current working directory.
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -26,7 +26,8 @@ full_custom_readme: |
     linuxserver/jenkins-builder:latest && \
   rm -f "$(basename $PWD).md" && \
   rm -f README.lite && \
-  rm -f .github/ISSUE_TEMPLATE.md
+  rm -f .github/ISSUE_TEMPLATE.md \
+  rm -f "$(basename $PWD).xml"
   ```
   Newly generated files (including `README.md`, `Jenkinsfile`, issue templates, etc.) will overwrite the existing files in your current working directory.
 

--- a/roles/generate-jenkins/defaults/main.yml
+++ b/roles/generate-jenkins/defaults/main.yml
@@ -46,3 +46,5 @@ changelogs: []
 custom_external_trigger: ""
 custom_package_trigger: ""
 external_trigger_delay_hours: 0
+unraid_template_sync: true
+unraid_template: true

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 #######################
 #   Set UID and GID   #
 #######################
@@ -131,6 +130,7 @@
     - lookup('env', 'LOCAL') != "true"
     - item.readme is not defined
     - item.donate is not defined
+    - item.unraid_template is not defined
     - item.package_trigger is not defined
     - item.external_trigger is not defined
   template:
@@ -146,6 +146,7 @@
     - lookup('env', 'LOCAL') == "true"
     - item.readme is not defined
     - item.donate is not defined
+    - item.unraid_template is not defined
     - item.package_trigger is not defined
     - item.external_trigger is not defined
   template:
@@ -230,6 +231,32 @@
     - lookup('env', 'LOCAL') == "true"
     - item.donate is defined
     - sponsor_links is defined
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "/tmp/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+# Unraid template templating
+
+- name: write Unraid template
+  when:
+    - lookup('env', 'LOCAL') != "true"
+    - item.donate is defined
+  template:
+    src: "../templates/{{ item.src }}"
+    dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
+    owner: "abc"
+    group: "abc"
+  delegate_to: localhost
+  loop: "{{  templated_files  }}"
+
+- name: write Unraid template local
+  when:
+    - lookup('env', 'LOCAL') == "true"
+    - item.unraid_template is defined
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -244,7 +244,10 @@
 - name: write Unraid template
   when:
     - lookup('env', 'LOCAL') != "true"
-    - item.donate is defined
+    - item.unraid_template is defined
+    - full_custom_readme is not defined
+    - '"baseimage" not in project_name'
+    - '"jenkins-builder" not in project_name'
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ github_project_name }}/{{ item.dest }}"
@@ -257,6 +260,9 @@
   when:
     - lookup('env', 'LOCAL') == "true"
     - item.unraid_template is defined
+    - full_custom_readme is not defined
+    - '"baseimage" not in project_name'
+    - '"jenkins-builder" not in project_name'
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -244,7 +244,7 @@
 - name: write Unraid template
   when:
     - lookup('env', 'LOCAL') != "true"
-    - unraid_template is defined and unraid_template is not sameas false
+    - unraid_template
     - item.unraid_template is defined
     - full_custom_readme is not defined
     - '"baseimage" not in project_name'
@@ -260,7 +260,7 @@
 - name: write Unraid template local
   when:
     - lookup('env', 'LOCAL') == "true"
-    - unraid_template is defined and unraid_template is not sameas false
+    - unraid_template
     - item.unraid_template is defined
     - full_custom_readme is not defined
     - '"baseimage" not in project_name'

--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -244,6 +244,7 @@
 - name: write Unraid template
   when:
     - lookup('env', 'LOCAL') != "true"
+    - unraid_template is defined and unraid_template is not sameas false
     - item.unraid_template is defined
     - full_custom_readme is not defined
     - '"baseimage" not in project_name'
@@ -259,6 +260,7 @@
 - name: write Unraid template local
   when:
     - lookup('env', 'LOCAL') == "true"
+    - unraid_template is defined and unraid_template is not sameas false
     - item.unraid_template is defined
     - full_custom_readme is not defined
     - '"baseimage" not in project_name'

--- a/roles/generate-jenkins/templates.yml
+++ b/roles/generate-jenkins/templates.yml
@@ -16,6 +16,7 @@ templated_files:
  - { src: 'greetings.j2', dest: '.github/workflows/greetings.yml' }
  - { src: 'stale.j2', dest: '.github/workflows/stale.yml' }
  - { src: 'CONTRIBUTING.j2', dest: '.github/CONTRIBUTING.md' }
+ - { src: 'UNRAID_TEMPLATE.j2', dest: "{{ project_name | lower }}.xml" , unraid_template: 'true' }
  - { src: 'PACKAGE_TRIGGER.j2', dest: '.github/workflows/package_trigger.yml', package_trigger: 'true' }
  - { src: 'PACKAGE_TRIGGER_SCHEDULER.j2', dest: '.github/workflows/package_trigger_scheduler.yml' }
  - { src: 'EXTERNAL_TRIGGER.j2', dest: '.github/workflows/external_trigger.yml', external_trigger: 'true' }

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -1,8 +1,10 @@
+{#- Create a real object from repo_vars -#}
 {%- set better_vars={} -%}
 {%- for i in repo_vars -%}
 {%- set i=(i | replace(' = ', '=', 1) | replace('=', '¯\_(ツ)_/¯', 1) | replace("'", "") | replace('"', "")).split('¯\_(ツ)_/¯') -%}
 {%- set x=(better_vars.__setitem__(i[0], i[1])) -%}
 {%- endfor -%}
+{#- Create a real object from repo_vars -#}
 name: External Trigger Main
 
 on:

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -422,13 +422,28 @@ pipeline {
               fi
               mkdir -p ${TEMPDIR}/gitbook
               git clone https://github.com/linuxserver/docker-documentation.git ${TEMPDIR}/gitbook/docker-documentation
-              if [[ "${BRANCH_NAME}" == "master" ]] && [[ (! -f ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md) || ("$(md5sum ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')") ]]; then
+              if [[ ("${BRANCH_NAME}" == "master") || ("${BRANCH_NAME}" == "main") ]] && [[ (! -f ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md) || ("$(md5sum ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')") ]]; then
                 cp ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md ${TEMPDIR}/gitbook/docker-documentation/images/
                 cd ${TEMPDIR}/gitbook/docker-documentation/
                 git add images/docker-${CONTAINER_NAME}.md
                 git commit -m 'Bot Updating Documentation'
                 git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/docker-documentation.git --all
               fi
+{% if "jenkins-builder" not in project_name and "baseimage" not in project_name and full_custom_readme is not defined %}
+              mkdir -p ${TEMPDIR}/unraid 
+              git clone https://github.com/linuxserver/docker-templates.git ${TEMPDIR}/unraid/docker-templates
+              git clone https://github.com/linuxserver/templates.git ${TEMPDIR}/unraid/templates
+              if [[ -f ${TEMPDIR}/unraid/docker-templates/linuxserver.io/img/${CONTAINER_NAME}.png ]]; then
+                sed -i "s|master/linuxserver.io/img/linuxserver-ls-logo.png|master/linuxserver.io/img/${CONTAINER_NAME}.png|" ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml
+              fi
+              if [[ ("${BRANCH_NAME}" == "master") || ("${BRANCH_NAME}" == "main") ]] && [[ (! -f ${TEMPDIR}/unraid/templates/unraid/${CONTAINER_NAME}.xml) || ("$(md5sum ${TEMPDIR}/unraid/templates/unraid/${CONTAINER_NAME}.xml | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml | awk '{ print $1 }')") ]]; then
+                cp ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml ${TEMPDIR}/unraid/templates/unraid/
+                cd ${TEMPDIR}/unraid/templates/
+                git add unraid/${CONTAINER_NAME}.xml
+                git commit -m 'Bot Updating Unraid Template'
+                git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/templates.git --all
+              fi
+{% endif %}
               rm -Rf ${TEMPDIR}'''
         script{
           env.FILES_UPDATED = sh(

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -429,12 +429,12 @@ pipeline {
                 git commit -m 'Bot Updating Documentation'
                 git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/docker-documentation.git --all
               fi
-{% if "jenkins-builder" not in project_name and "baseimage" not in project_name and full_custom_readme is not defined and unraid_template %}
+{% if "jenkins-builder" not in project_name and "baseimage" not in project_name and full_custom_readme is not defined and unraid_template == true %}
               mkdir -p ${TEMPDIR}/unraid 
               git clone https://github.com/linuxserver/docker-templates.git ${TEMPDIR}/unraid/docker-templates
               git clone https://github.com/linuxserver/templates.git ${TEMPDIR}/unraid/templates
-              if [[ -f ${TEMPDIR}/unraid/docker-templates/linuxserver.io/img/${CONTAINER_NAME}.png ]]; then
-                sed -i "s|master/linuxserver.io/img/linuxserver-ls-logo.png|master/linuxserver.io/img/${CONTAINER_NAME}.png|" ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml
+              if [[ -f ${TEMPDIR}/unraid/docker-templates/linuxserver.io/img/${CONTAINER_NAME}-icon.png ]]; then
+                sed -i "s|master/linuxserver.io/img/linuxserver-ls-logo.png|master/linuxserver.io/img/${CONTAINER_NAME}-icon.png|" ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml
               fi
               if [[ ("${BRANCH_NAME}" == "master") || ("${BRANCH_NAME}" == "main") ]] && [[ (! -f ${TEMPDIR}/unraid/templates/unraid/${CONTAINER_NAME}.xml) || ("$(md5sum ${TEMPDIR}/unraid/templates/unraid/${CONTAINER_NAME}.xml | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml | awk '{ print $1 }')") ]]; then
                 if grep -wq "${CONTAINER_NAME}" ${TEMPDIR}/unraid/templates/unraid/ignore.list; then

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -429,7 +429,7 @@ pipeline {
                 git commit -m 'Bot Updating Documentation'
                 git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/docker-documentation.git --all
               fi
-{% if "jenkins-builder" not in project_name and "baseimage" not in project_name and full_custom_readme is not defined %}
+{% if "jenkins-builder" not in project_name and "baseimage" not in project_name and full_custom_readme is not defined and unraid_template %}
               mkdir -p ${TEMPDIR}/unraid 
               git clone https://github.com/linuxserver/docker-templates.git ${TEMPDIR}/unraid/docker-templates
               git clone https://github.com/linuxserver/templates.git ${TEMPDIR}/unraid/templates
@@ -437,11 +437,15 @@ pipeline {
                 sed -i "s|master/linuxserver.io/img/linuxserver-ls-logo.png|master/linuxserver.io/img/${CONTAINER_NAME}.png|" ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml
               fi
               if [[ ("${BRANCH_NAME}" == "master") || ("${BRANCH_NAME}" == "main") ]] && [[ (! -f ${TEMPDIR}/unraid/templates/unraid/${CONTAINER_NAME}.xml) || ("$(md5sum ${TEMPDIR}/unraid/templates/unraid/${CONTAINER_NAME}.xml | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml | awk '{ print $1 }')") ]]; then
-                cp ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml ${TEMPDIR}/unraid/templates/unraid/
-                cd ${TEMPDIR}/unraid/templates/
-                git add unraid/${CONTAINER_NAME}.xml
-                git commit -m 'Bot Updating Unraid Template'
-                git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/templates.git --all
+                if grep -wq "${CONTAINER_NAME}" ${TEMPDIR}/unraid/templates/unraid/ignore.list; then
+                  echo "Image is on the ignore list, skipping Unraid template upload"
+                else
+                  cp ${TEMPDIR}/docker-${CONTAINER_NAME}/${CONTAINER_NAME}.xml ${TEMPDIR}/unraid/templates/unraid/
+                  cd ${TEMPDIR}/unraid/templates/
+                  git add unraid/${CONTAINER_NAME}.xml
+                  git commit -m 'Bot Updating Unraid Template'
+                  git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/templates.git --all
+                fi
               fi
 {% endif %}
               rm -Rf ${TEMPDIR}'''

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -1,0 +1,132 @@
+{#- Create a real object from repo_vars -#}
+{%- set better_vars={} -%}
+{%- for i in repo_vars -%}
+{%- set i=(i | replace(" = ", "=", 1) | replace("'", "") | replace('"', "")).split('=') -%}
+{%- set x=(better_vars.__setitem__(i[0], i[1])) -%}
+{%- endfor -%}
+{#- Create a real object from repo_vars -#}
+{#- Create ExtraParam for REQUIRED stuff-#}
+{%- set ExtraParam=[] -%}
+{%- set x=ExtraParam.append(param_hostname) if param_usage_include_hostname is sameas true -%}
+{%- if cap_add_param is defined -%}
+{%- for item in cap_add_param_vars -%}
+{%- set x=ExtraParam.append("--cap-add=" + item.cap_add_var) -%}
+{%- endfor -%}
+{#- custom_params -#}
+{%- if custom_params is defined -%}
+{%- for item in custom_params -%}
+{%- if item.array is not defined -%}
+{%- set x=ExtraParam.append("--" + item.name+ "=" + item.value) -%}
+{%- else -%}
+{%- for item2 in item.value -%}
+{%- set x=ExtraParam.append("--" + item.name+ "=" + item2) -%}
+{%- endfor -%}
+{%- endif -%}
+{%- endfor -%}
+{%- endif -%}
+{%- endif -%}
+{#- Create ExtraParam for REQUIRED stuff-#}
+<?xml version="1.0"?>
+<Container version="2">
+    <Name>{{ param_container_name | lower }}</Name>
+    <Repository>ghcr.io/{{ lsio_project_name_short }}/{{ project_name }}</Repository>
+    <Registry>https://github.com/orgs/{{ lsio_project_name_short }}/packages/container/package/{{ project_name }}</Registry>
+    <DonateText>Donations</DonateText>
+    <DonateLink>https://www.linuxserver.io/donate</DonateLink>
+    <DonateImg>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/donate.png</DonateImg>
+    <Network>{{ param_net if param_usage_include_net is sameas true else 'bridge' }}</Network>
+    <Privileged>{{ "true" if privileged is sameas true else "false" }}</Privileged>
+    <Support>https://www.linuxserver.io/support</Support>
+{# Set the Branches, if any #}
+{% if development_versions is defined and development_versions %}
+{% for item in development_versions_items %}
+    <Branch>
+        <Tag>{{ item.tag }}</Tag>
+        <TagDescription>{{ item.desc }}</TagDescription>
+{% if item.extra is defined %} {#- Allow for branch-specific stuff #}
+        {{ item.extra | indent(8) | trim }}
+{% endif %}
+    </Branch>
+{% endfor %}
+{% endif %}
+{# Set the Branches, if any #}
+    <Project>{{ project_url }}</Project>
+    <Overview>{{ project_blurb | trim }}</Overview>
+{# Set the ExtraParmas, if any #}
+{% if ExtraParam is defined and ExtraParam!=[] %}
+    <ExtraParams>{{ ExtraParam|join(" ") }}</ExtraParams>
+{% endif %}
+{# Set the WebUI link based on the link the CI runs against #}
+{% if better_vars.get("CI_WEB") and better_vars.get("CI") == "true" %}
+    <WebUI>{{ "https" if better_vars.get("CI_SSL") == "true" else "http" }}://[IP]:[PORT:{{ better_vars.get("CI_PORT") }}]</WebUI>
+{% endif %}
+{# Set the WebUI link based on the link the CI runs against #}
+    <TemplateURL>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/{{ project_name | lower }}.xml</TemplateURL>
+    <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/digikam.png</Icon>
+{# Set required ports, gets the name from the name atribute if present, or "WebUI" if it is the first port #}
+{% if param_usage_include_ports | default(false) %}
+{% for item in param_ports %}
+{% set port, proto=item.internal_port.split('/') if "/" in item.internal_port else [item.internal_port, false] %} {#- Logic to get the protocol #}
+    <Config Name="{{ item.name if item.name is defined else "WebUI" if loop.first else "Port: " + port }}" Target="{{ port }}" Default="{{ item.external_port }}" Mode="{{ proto if proto else "tcp" }}" Description="{{ item.port_desc if item.port_desc is defined else "Container Port: " + port }}" Type="Port" Display="always" Required="true" Mask="false"/>
+{% endfor %}
+{% endif %}
+{#- Set required ports, gets the name from the name atribute if present, or "WebUI" if it is the first port #}
+{#- Set optional ports #}
+{% if opt_param_usage_include_ports | default(false) %}
+{% for item in opt_param_ports %}
+{% set port, proto=item.internal_port.split('/') if "/" in item.internal_port else [item.internal_port, false] %} {#- Logic to get the protocol #}
+    <Config Name="{{ item.name if item.name is defined else "Port: " + port }}" Target="{{ port }}" Default="{{ item.external_port }}" Mode="{{ proto if proto else "tcp" }}" Description="{{ item.port_desc if item.port_desc is defined else "Container Port: " + port }}" Type="Port" Display="always" Required="false" Mask="false"/>
+{% endfor %}
+{% endif %}
+{#- Set optional ports #}
+{#- Set required volumes, gets the name from the name atribute if present, or "Appdata" if it is the /config location #}
+{% if param_usage_include_vols | default(false) %}
+{% for item in param_volumes %}
+{% set path, mode=item.vol_path.split(':') if ":" in item.vol_path else [item.vol_path, false] %} {#- Logic to get the mode #}
+    <Config Name="{{ item.name if item.name is defined else "Appdata" if path == "/config" else "Path: " + path }}" Target="{{ path }}" Default="" Mode="{{ mode if mode else "rw" }}" Description="{{ item.desc if item.desc is defined else "Path: " + path }}" Type="Path" Display="always" Required="true" Mask="false"/>
+{% endfor %}
+{% endif %}
+{#- Set required volumes, gets the name from the name atribute if present, or "Appdata" if it is the /config location #}
+{#- Set optional volumes #}
+{% if opt_param_usage_include_vols | default(false) %}
+{% for item in opt_param_volumes %}
+{% set path, mode=item.vol_path.split(':') if ":" in item.vol_path else [item.vol_path, false] %} {#- Logic to get the mode #}
+    <Config Name="{{ item.name if item.name is defined else "Appdata" if path == "/config" else "Path: " + path }}" Target="{{ path }}" Default="" Mode="{{ mode if mode else "rw" }}" Description="{{ item.desc if item.desc is defined else "Path: " + path }}" Type="Path" Display="always" Required="false" Mask="false"/>
+{% endfor %}
+{% endif %}
+{#- Set optional volumes #}
+{% set skip_envs=["puid", "pgid", "tz"] %} {#- Drop envs that are either hardcoded, or automaticcly added by unraid #}
+{#- Set required variables, gets the name from the name atribute #}
+{% if param_usage_include_env | default(false) %}
+{% for item in param_env_vars if not item.env_var | lower is in skip_envs %}
+{% set mask="true" if item.env_var | lower is in ["token", "pass", "token", "key"] else item.mask if item.mask is defined else "false" %} {#- Crude logic to determine if the env should be masked #}
+    <Config Name="{{ item.name if item.name is defined else item.env_var }}" Target="{{ item.env_var }}" Default="{{ item.env_value }}" Description="{{ item.desc if item.desc is defined else "Variable: " + path }}" Type="Variable" Display="always" Required="true" Mask="{{ mask }}"/>
+{% endfor %}
+{% endif %}
+{#- Set required variables, gets the name from the name atribute #}
+{#- Set optional variables #}
+{% if opt_param_usage_include_env | default(false) %}
+{% for item in opt_param_env_vars if not item.env_var | lower is in skip_envs %}
+{% set mask="true" if item.env_var | lower is in ["token", "pass", "token", "key"] else item.mask if item.mask is defined else "false" %} {#- Crude logic to determine if the env should be masked #}
+    <Config Name="{{ item.name if item.name is defined else item.env_var }}" Target="{{ item.env_var }}" Default="{{ item.env_value }}" Description="{{ item.desc if item.desc is defined else "Variable: " + path }}" Type="Variable" Display="always" Required="false" Mask="{{ mask }}"/>
+{% endfor %}
+{% endif %}
+{#- Set optional variables #}
+    <Config Name="PUID" Target="PUID" Default="99" Description="Container Variable: PUID" Type="Variable" Display="always" Required="false" Mask="false"/>
+    <Config Name="PGID" Target="PGID" Default="100" Description="Container Variable: PGID" Type="Variable" Display="always" Required="false" Mask="false"/>
+{#- Set required devices, gets the name from the name atribute #}
+{% if param_device_map | default(false) %}
+{% for item in param_devices %}
+    <Config Name="{{ item.name if item.name is defined else item.device_path }}" Default="{{ item.device_path }}" Description="{{ item.desc if item.desc is defined else "Device: " + path }}" Type="Device" Display="always" Required="true" Mask="false"/>
+{% endfor %}
+{% endif %}
+{#- Set required variables, gets the name from the name atribute #}
+{#- Set optional devices #}
+{% if opt_param_device_map | default(false) %}
+{% for item in opt_param_devices %}
+    <Config Name="{{ item.name if item.name is defined else item.device_path }}" Default="{{ item.device_path }}" Description="{{ item.desc if item.desc is defined else "Device: " + path }}" Type="Device" Display="always" Required="true" Mask="false"/>
+{% endfor %}
+{% endif %}
+{# Set optional devices #}
+
+</Container>

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -36,7 +36,7 @@
     <DonateImg>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/donate.png</DonateImg>
     <Network>{{ param_net if param_usage_include_net is sameas true else 'bridge' }}</Network>
     <Privileged>{{ "true" if privileged is sameas true else "false" }}</Privileged>
-    <Support>https://www.linuxserver.io/support</Support>
+    <Support>{{ lsio_github_url }}/{{ project_repo_name }}/issues/new/choose</Support>
 {# Set the Branches, if any #}
 {% if development_versions is defined and development_versions %}
 {% for item in development_versions_items %}

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -1,7 +1,7 @@
 {#- Create a real object from repo_vars -#}
 {%- set better_vars={} -%}
 {%- for i in repo_vars -%}
-{%- set i=(i | replace(" = ", "=", 1) | replace("'", "") | replace('"', "")).split('=') -%}
+{%- set i=(i | replace(' = ', '=', 1) | replace('=', '¯\_(ツ)_/¯', 1) | replace("'", "") | replace('"', "")).split('¯\_(ツ)_/¯') -%}
 {%- set x=(better_vars.__setitem__(i[0], i[1])) -%}
 {%- endfor -%}
 {#- Create a real object from repo_vars -#}
@@ -27,7 +27,7 @@
 {%- endif -%}
 {#- Create ExtraParam for REQUIRED stuff-#}
 <?xml version="1.0"?>
-<!-- DO NOT CHANGE THIS FILE MANUALLY, IT IS AUTOMATICCLY GENERATED -->
+<!-- DO NOT CHANGE THIS FILE MANUALLY, IT IS AUTOMATICALLY GENERATED -->
 <Container version="2">
     <Name>{{ param_container_name | lower }}</Name>
     <Repository>ghcr.io/{{ lsio_project_name_short }}/{{ project_name }}</Repository>

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -62,7 +62,7 @@
 {% endif %}
 {# Set the WebUI link based on the link the CI runs against #}
     <TemplateURL>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/{{ project_name | lower }}.xml</TemplateURL>
-    <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/{{ project_name | lower }}.png</Icon>
+    <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver-ls-logo.png</Icon>
 {# Set required ports, gets the name from the name atribute if present, or "WebUI" if it is the first port #}
 {% if param_usage_include_ports | default(false) %}
 {% for item in param_ports %}

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -62,7 +62,7 @@
 {% endif %}
 {# Set the WebUI link based on the link the CI runs against #}
     <TemplateURL>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/{{ project_name | lower }}.xml</TemplateURL>
-    <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/digikam.png</Icon>
+    <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/{{ project_name | lower }}.png</Icon>
 {# Set required ports, gets the name from the name atribute if present, or "WebUI" if it is the first port #}
 {% if param_usage_include_ports | default(false) %}
 {% for item in param_ports %}

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -27,6 +27,7 @@
 {%- endif -%}
 {#- Create ExtraParam for REQUIRED stuff-#}
 <?xml version="1.0"?>
+<!-- DO NOT CHANGE THIS FILE MANUALLY, IT IS AUTOMATICCLY GENERATED -->
 <Container version="2">
     <Name>{{ param_container_name | lower }}</Name>
     <Repository>ghcr.io/{{ lsio_project_name_short }}/{{ project_name }}</Repository>
@@ -61,7 +62,7 @@
     <WebUI>{{ "https" if better_vars.get("CI_SSL") == "true" else "http" }}://[IP]:[PORT:{{ better_vars.get("CI_PORT") }}]</WebUI>
 {% endif %}
 {# Set the WebUI link based on the link the CI runs against #}
-    <TemplateURL>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/{{ project_name | lower }}.xml</TemplateURL>
+    <TemplateURL>{{ "false" if unraid_template_sync is sameas false else "https://raw.githubusercontent.com/linuxserver/templates/main/unraid/" + project_name | lower + ".xml" }}</TemplateURL>
     <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver-ls-logo.png</Icon>
 {# Set required ports, gets the name from the name atribute if present, or "WebUI" if it is the first port #}
 {% if param_usage_include_ports | default(false) %}

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -20,7 +20,15 @@ available_architectures:
 development_versions: false
 development_versions_items:
   - { tag: "latest", desc: "Stable Ombi releases" }
-  - { tag: "development", desc: "Releases from the `develop` branch of Ombi" }
+  - tag: "development"
+    desc: "Releases from the `develop` branch of Ombi"
+    extra: |
+      <Environment>
+          <Variable>
+              <Name>SomeDevelopSpecificVar</Name>
+              <Value>1337</Value>
+          </Variable>
+      </Environment>
 
 
 # container parameters
@@ -34,16 +42,16 @@ param_net: "host"
 param_net_desc: "Shares host networking with container."
 param_usage_include_env: true
 param_env_vars:
-  - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
+  - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London.", name: "Timezone" }
 param_usage_include_vols: true
 param_volumes:
-  - { vol_path: "/config", vol_host_path: "</path/to/appdata/config>", desc: "Configuration files." }
+  - { vol_path: "/config", vol_host_path: "</path/to/appdata/config>", desc: "Configuration files.", name: "Appdata" }
 param_usage_include_ports: true
 param_ports:
-  - { external_port: "80", internal_port: "80", port_desc: "Application WebUI" }
+  - { external_port: "80", internal_port: "80", port_desc: "Application WebUI", name: "WebUI" }
 param_device_map: false
 param_devices:
-  - { device_path: "/dev/dri", device_host_path: "/dev/dri", desc: "For hardware transcoding" }
+  - { device_path: "/dev/dri", device_host_path: "/dev/dri", desc: "For hardware transcoding", name: "QuckSync" }
 cap_add_param: false
 cap_add_param_vars:
   - { cap_add_var: "NET_ADMIN" }
@@ -51,16 +59,16 @@ cap_add_param_vars:
 # optional container parameters
 opt_param_usage_include_env: false
 opt_param_env_vars:
-  - { env_var: "VERSION", env_value: "latest", desc: "Supported values are LATEST, PLEXPASS or a specific version number." }
+  - { env_var: "VERSION", env_value: "latest", desc: "Supported values are LATEST, PLEXPASS or a specific version number.", name: "Version" }
 opt_param_usage_include_vols: false
 opt_param_volumes:
-  - { vol_path: "/config", vol_host_path: "</path/to/appdata/config>", desc: "Configuration files." }
+  - { vol_path: "/config", vol_host_path: "</path/to/appdata/config>", desc: "Configuration files.", name: "Config" }
 opt_param_usage_include_ports: false
 opt_param_ports:
-  - { external_port: "80", internal_port: "80", port_desc: "Application WebUI" }
+  - { external_port: "80", internal_port: "80", port_desc: "Application WebUI", name: "WebUI" }
 opt_param_device_map: false
 opt_param_devices:
-  - { device_path: "/dev/dri", device_host_path: "/dev/dri", desc: "For hardware transcoding" }
+  - { device_path: "/dev/dri", device_host_path: "/dev/dri", desc: "For hardware transcoding", name: "QuckSync" }
 opt_cap_add_param: false
 opt_cap_add_param_vars:
   - { cap_add_var: "NET_ADMIN" }

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -73,6 +73,10 @@ opt_cap_add_param: false
 opt_cap_add_param_vars:
   - { cap_add_var: "NET_ADMIN" }
 
+# Unraid templating
+# Disables the sync function on unraids side. On by default
+unraid_template_sync: true
+
 optional_block_1: false
 optional_block_1_items:
   - "```"

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -76,6 +76,7 @@ opt_cap_add_param_vars:
 # Unraid templating
 # Disables the sync function on unraids side. On by default
 unraid_template_sync: true
+unraid_template: true
 
 optional_block_1: false
 optional_block_1_items:


### PR DESCRIPTION
- Add unraid templating support:
  - New vars for `jenkins-vars.yml`: `unraid_template` (default `true`) and `unraid_template_sync` (default `true`)
  - Push unraid templates to new repo: https://github.com/linuxserver/templates
  - Create ignore list at the templates repo: https://github.com/linuxserver/templates/blob/main/unraid/ignore.list
  - Templates will look for icons named `CONTAINERNAME-icon.png` in the docker-templates repo images, if not existing, it will use the lsio logo
  - Templating will ignore any repo with `jenkins-builder` and `baseimage` in the name, as well as ones that have `unraid_template` set to `false` and ones that are listed in the `ignore.list`
- Accept `main` as alternative default branch for pushing docs and unraid templates
- Update readme local jenkins-builder command to also delete the unraid template
