### PR TITLE
Reduce ambiguity in what types of fixes need issues vs PR

### DIFF
--- a/roles/generate-jenkins/templates/CONTRIBUTING.j2
+++ b/roles/generate-jenkins/templates/CONTRIBUTING.j2
@@ -4,7 +4,7 @@
 
 * While contributing make sure to make all your changes before creating a Pull Request, as our pipeline builds each commit after the PR is open.
 * Read, and fill the Pull Request template
-  * If this is a fix for a typo in code or documentation in the README please file an issue
+  * If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR
   * If the PR is addressing an existing issue include, closes #\<issue number>, in the body of the PR commit message
 * If you want to discuss changes, you can also bring it up in [#dev-talk](https://discordapp.com/channels/354974912613449730/757585807061155840) in our [Discord server]({{ lsio_discord_url }})
 

--- a/roles/generate-jenkins/templates/PULL_REQUEST_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/PULL_REQUEST_TEMPLATE.j2
@@ -13,7 +13,7 @@ This image is deprecated. We will not offer support for this image and it will n
 
 <!--- Before submitting a pull request please check the following -->
 
-<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
+<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
 <!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  {{ lsio_blog_url }}/2019/09/14/customizing-our-containers/ -->
 <!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
 <!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jenkins-builder/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
While contributing to `docker-homeassistant` I was asked not to make an issue AND a PR for the same fix but the only reason I did both was because I read the CONTRIBUTING.md thought I should open an issue first. It was only after I made the issue, then I saw PULL_REQUEST_TEMPLATE.md which made it sound like I shouldn't have opened the issue (but still wasn't clear).

This is a small language change that would've been more clear to me.

## Benefits of this PR and context:
I was confused because I read the original text as "If this is a fix for a typo in code OR a fix for documentation in the README please file an issue" instead of "If this is a fix for a typo in code OR a typo in docs...". Since I was fixing the README, I filed an issue first.

I assume this language is to reduce typo related PR spam and I think my changes can make that more clear.

## How Has This Been Tested?
I ran the generator against itself and double checked the `.github/CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md`


## Source / References:
 - https://github.com/linuxserver/docker-homeassistant/issues/11#issuecomment-862055142
 - https://discord.com/channels/354974912613449730/757585807061155840/854967622500089906