### PR TITLE
Add fedora

### DIFF
--- a/package_versions.txt
+++ b/package_versions.txt
@@ -1,6 +1,6 @@
 alpine-baselayout-3.2.0-r8
 alpine-keys-2.2-r0
-ansible-2.10.6-r0
+ansible-2.10.7-r0
 ansible-base-2.10.5-r0
 apk-tools-2.12.5-r0
 bash-5.1.0-r0
@@ -21,8 +21,8 @@ libproc-3.3.16-r0
 libssl1.1-1.1.1k-r0
 libtls-standalone-2.9.1-r1
 linux-pam-1.5.1-r0
-musl-1.2.2-r0
-musl-utils-1.2.2-r0
+musl-1.2.2-r1
+musl-utils-1.2.2-r1
 ncurses-libs-6.2_p20210109-r0
 ncurses-terminfo-base-6.2_p20210109-r0
 procps-3.3.16-r0

--- a/package_versions.txt
+++ b/package_versions.txt
@@ -41,7 +41,7 @@ py3-parsing-2.4.7-r1
 py3-pynacl-1.4.0-r0
 py3-six-1.15.0-r0
 py3-yaml-5.3.1-r2
-python3-3.8.8-r0
+python3-3.8.10-r0
 readline-8.1.0-r0
 s6-ipcserver-2.10.0.0-r0
 scanelf-1.2.8-r0

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -721,6 +721,12 @@ pipeline {
                   sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
                   chmod 777 /tmp/package_versions.txt'
               fi
+              elif [ "${DIST_IMAGE}" == "fedora" ]; then
+                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
+                  rpm -qa > /tmp/package_versions.txt && \
+                  sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
+                  chmod 777 /tmp/package_versions.txt'
+              fi
               NEW_PACKAGE_TAG=$(md5sum ${TEMPDIR}/package_versions.txt | cut -c1-8 )
               echo "Package tag sha from current packages in buit container is ${NEW_PACKAGE_TAG} comparing to old ${PACKAGE_TAG} from github"
               if [ "${NEW_PACKAGE_TAG}" != "${PACKAGE_TAG}" ]; then

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -720,7 +720,6 @@ pipeline {
                   apt list -qq --installed | sed "s#/.*now ##g" | cut -d" " -f1 > /tmp/package_versions.txt && \
                   sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
                   chmod 777 /tmp/package_versions.txt'
-              fi
               elif [ "${DIST_IMAGE}" == "fedora" ]; then
                 docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
                   rpm -qa > /tmp/package_versions.txt && \


### PR DESCRIPTION
This adds an if stanza to support dumping package versions for fedora. The logic is pretty simple just an `rpm -qa` and sort.
The additional functionality has been added to the ci  container in: 
https://github.com/linuxserver/docker-ci/commit/bdefc97df209dc26a1bc71f613208ac9b4d662c3
Should be able to merge before the July monthly is pushed. 