### PR TITLE
allow building on native armhf via jenkins var

### DIFF
--- a/roles/generate-jenkins/defaults/main.yml
+++ b/roles/generate-jenkins/defaults/main.yml
@@ -48,3 +48,4 @@ custom_package_trigger: ""
 external_trigger_delay_hours: 0
 unraid_template_sync: true
 unraid_template: true
+armhf_native: false

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -626,6 +626,8 @@ pipeline {
           agent {
 {% if use_qemu is defined %}
             label 'X86-64-MULTI'
+{% elif armhf_native %}
+            label 'ARMHF-NATIVE'
 {% else %}
             label 'ARMHF'
 {% endif %}


### PR DESCRIPTION
Adding `armhf_native: true` to jenkins-vars.yml will set the armhf jenkins builder label to `ARMHF_NATIVE`. The current three native builders already have the new label added.

`use_qemu: true` will override this behavior and will build on x86 even if `armhf_native` is set to true.