### PR TITLE
added semver tag from external release number

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -773,6 +773,7 @@ pipeline {
                     docker manifest push --purge ${MANIFESTIMAGE}:latest
                     docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG} 
                     docker manifest push --purge ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} 
+                    docker manifest push --purge ${MANIFESTIMAGE}:${SEMVER} 
                   done
                '''
           }

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -999,6 +999,7 @@ pipeline {
                     docker manifest push --purge ${MANIFESTIMAGE}:{{ release_tag }}
                     docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG}{{ ' ' }}
                     docker manifest push --purge ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}{{ ' ' }}
+                    docker manifest push --purge ${MANIFESTIMAGE}:${SEMVER}{{ ' ' }}
                   done
                '''
           }


### PR DESCRIPTION
By default, this will extract the semver from an upstream release (`x.x.x`). Any prefix or suffixes outside of that are discarded. If the version matches a partial (ex: `x.x`), then this PR currently appends the current `YYYYMMDD` as the third portion of the version.

If neither of the above matches, the version used to tag the image as semvar will be the date in the format of `YYYY.MM.DD`.