### PR TITLE
add ability to set security options in the readme

### DIFF
--- a/roles/generate-jenkins/defaults/main.yml
+++ b/roles/generate-jenkins/defaults/main.yml
@@ -19,6 +19,10 @@ cap_add_param: false
 cap_add_param_vars: []
 opt_cap_add_param: false
 opt_cap_add_param_vars: []
+security_opt_param: false
+security_opt_param_vars: []
+opt_security_opt_param: false
+opt_security_opt_param_vars: []
 param_usage_include_hostname: false
 param_hostname: ""
 param_usage_include_env: false

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -102,6 +102,19 @@ services:
       - {{ item.cap_add_var }} #optional
 {% endfor %}
 {% endif %}
+{% if security_opt_param or opt_security_opt_param %}
+    security_opt:
+{% endif %}
+{% if security_opt_param %}
+{% for item in security_opt_param_vars %}
+      - {{ item.compose_var }}
+{% endfor %}
+{% endif %}
+{% if opt_security_opt_param %}
+{% for item in opt_security_opt_param_vars %}
+      - {{ item.compose_var }} #optional
+{% endfor %}
+{% endif %}
 {% if param_usage_include_net is sameas true %}
     network_mode: {{ param_net }}
 {% elif param_usage_include_net == 'optional' %}
@@ -224,6 +237,16 @@ docker run -d \
 {% if opt_cap_add_param %}
 {% for item in opt_cap_add_param_vars %}
   --cap-add={{ item.cap_add_var }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if security_opt_param %}
+{% for item in security_opt_param_vars %}
+  --security-opt={{ item.run_var }} \
+{% endfor %}
+{% endif %}
+{% if opt_security_opt_param %}
+{% for item in opt_security_opt_param_vars %}
+  --security-opt {{ item.run_var }} `#optional` \
 {% endfor %}
 {% endif %}
 {% if common_param_env_vars_enabled is sameas true %}
@@ -384,7 +407,7 @@ Docker images are configured using parameters passed at runtime (such as those a
 {% endfor %}
 {% endif %}
 {% endif %}
-{% if custom_params is defined or opt_custom_params is defined or param_usage_include_hostname %}
+{% if custom_params is defined or opt_custom_params is defined or param_usage_include_hostname or security_opt_param is defined or opt_security_opt_param is defined %}
 
 #### Miscellaneous Options
 
@@ -401,6 +424,16 @@ Docker images are configured using parameters passed at runtime (such as those a
 {% if opt_custom_params is defined %}
 {% for item in opt_custom_params %}
 | `--{{ item.name }}=` | {{ item.desc }} |
+{% endfor %}
+{% endif %}
+{% if security_opt_param %}
+{% for item in security_opt_param_vars %}
+| `--security-opt {{ item.run_security_opt_var }}` | {{ item.desc }} |
+{% endfor %}
+{% endif %}
+{% if opt_security_opt_param %}
+{% for item in opt_security_opt_param_vars %}
+| `--security-opt {{ item.run_var }}` | {{ item.desc }} |
 {% endfor %}
 {% endif %}
 {% endif %}

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -126,6 +126,19 @@ services:
       - {{ item.cap_add_var }} #optional
 {% endfor %}
 {% endif %}
+{% if security_opt_param or opt_security_opt_param %}
+    security_opt:
+{% endif %}
+{% if security_opt_param %}
+{% for item in security_opt_param_vars %}
+      - {{ item.compose_var }}
+{% endfor %}
+{% endif %}
+{% if opt_security_opt_param %}
+{% for item in opt_security_opt_param_vars %}
+      - {{ item.compose_var }} #optional
+{% endfor %}
+{% endif %}
 {% if param_usage_include_net is sameas true %}
     network_mode: {{ param_net }}
 {% elif param_usage_include_net == 'optional' %}
@@ -248,6 +261,16 @@ docker run -d \
 {% if opt_cap_add_param %}
 {% for item in opt_cap_add_param_vars %}
   --cap-add={{ item.cap_add_var }} `#optional` \
+{% endfor %}
+{% endif %}
+{% if security_opt_param %}
+{% for item in security_opt_param_vars %}
+  --security-opt={{ item.run_var }} \
+{% endfor %}
+{% endif %}
+{% if opt_security_opt_param %}
+{% for item in opt_security_opt_param_vars %}
+  --security-opt {{ item.run_var }} `#optional` \
 {% endfor %}
 {% endif %}
 {% if common_param_env_vars_enabled is sameas true %}
@@ -395,6 +418,16 @@ Container images are configured using parameters passed at runtime (such as thos
 {% if opt_custom_params is defined %}
 {% for item in opt_custom_params %}
 | `--{{ item.name }}=` | {{ item.desc }} |
+{% endfor %}
+{% endif %}
+{% if security_opt_param %}
+{% for item in security_opt_param_vars %}
+| `--security-opt {{ item.run_security_opt_var }}` | {{ item.desc }} |
+{% endfor %}
+{% endif %}
+{% if opt_security_opt_param %}
+{% for item in opt_security_opt_param_vars %}
+| `--security-opt {{ item.run_var }}` | {{ item.desc }} |
 {% endfor %}
 {% endif %}
 

--- a/roles/generate-jenkins/templates/lite.j2
+++ b/roles/generate-jenkins/templates/lite.j2
@@ -48,6 +48,16 @@ docker run -d \
   --cap-add={{ item.cap_add_var }} `#optional` \
 {% endfor %}
 {% endif %}
+{% if security_opt_param %}
+{% for item in security_opt_param_vars %}
+  --security-opt={{ item.run_var }} \
+{% endfor %}
+{% endif %}
+{% if opt_security_opt_param %}
+{% for item in opt_security_opt_param_vars %}
+  --security-opt {{ item.run_var }} `#optional` \
+{% endfor %}
+{% endif %}
 {% if common_param_env_vars_enabled is sameas true %}
 {% for item in common_param_env_vars %}
   -e {{ item.env_var }}={{ item.env_value }} \

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -60,6 +60,9 @@ param_devices:
 cap_add_param: false
 cap_add_param_vars:
   - { cap_add_var: "NET_ADMIN" }
+security_opt_param: false
+security_opt_param_vars:
+  - { run_var: "seccomp=unconfined", compose_var: "seccomp:unconfined", desc: "Disabled syscall filtering" }
 
 # optional container parameters
 opt_param_usage_include_env: false
@@ -77,6 +80,9 @@ opt_param_devices:
 opt_cap_add_param: false
 opt_cap_add_param_vars:
   - { cap_add_var: "NET_ADMIN" }
+security_opt_param: false
+security_opt_param_vars:
+  - { run_var: "seccomp=unconfined", compose_var: "seccomp:unconfined", desc: "Disabled syscall filtering" }
 
 # Unraid templating
 # Disables the sync function on unraids side. On by default


### PR DESCRIPTION
Webtop needs to be able to set seccomp unconfied until this https://github.com/docker/for-linux/issues/1262 is resolved so we need to present that as an optional var in the readme. 