### PR TITLE
Fix inconsistent variables

### DIFF
--- a/roles/generate-jenkins/defaults/main.yml
+++ b/roles/generate-jenkins/defaults/main.yml
@@ -45,6 +45,10 @@ opt_param_device_map: false
 opt_param_devices: []
 app_setup_block_enabled: false
 app_setup_block: ""
+external_application_snippet_enabled: false
+external_application_cli_block: ""
+external_application_compose_block: ""
+external_application_unraid_block: ""
 optional_block_1: false
 changelogs: []
 custom_external_trigger: ""

--- a/roles/generate-jenkins/defaults/main.yml
+++ b/roles/generate-jenkins/defaults/main.yml
@@ -45,8 +45,6 @@ opt_param_device_map: false
 opt_param_devices: []
 app_setup_block_enabled: false
 app_setup_block: ""
-nginx_reverse_proxy_snippet_enabled: false
-nginx_reverse_proxy_block: ""
 optional_block_1: false
 changelogs: []
 custom_external_trigger: ""

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -240,6 +240,11 @@ services:
 {% endfor %}
 {% endif %}
     restart: unless-stopped{% else %}{{ custom_compose }}{% endif %}
+{% if external_application_snippet_enabled %}
+
+# This container requires an external application to be run separately.
+{{ external_application_compose_block }}
+{% endif %}
 
 ```
 
@@ -377,6 +382,12 @@ docker run -d \
 {% endif %}
   --restart unless-stopped \
   lscr.io/{{ lsio_project_name_short }}/{{ project_name }}:{{ release_tag }}
+{% if external_application_snippet_enabled %}
+
+# This container requires an external application to be run separately.
+{{ external_application_cli_block }}
+{% endif %}
+
 ```
 
 {% if optional_block_1 %}

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -547,13 +547,6 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 [![Docker Mods]({{ lsio_shieldsio_dynamic_mods }})]({{ lsio_mods_url }} "{{ lsio_mods_desc }}") [![Docker Universal Mods]({{ lsio_shieldsio_dynamic_universal_mods }})]({{ lsio_universal_mods_url }} "{{ lsio_universal_mods_desc }}")
 
 We publish various [Docker Mods]({{ lsio_github_url }}/docker-mods) to enable additional functionality within the containers. The list of Mods available for this image (if any) as well as universal mods that can be applied to any one of our images can be accessed via the dynamic badges above.
-{% if nginx_reverse_proxy_snippet_enabled %}
-
-## Reverse Proxy Snippet
-
-This snippet has been tested with {{ lsio_project_name|capitalize}}'s [Secure Web Application Gateway]({{ lsio_github_url }}/docker-swag) container.
-{{ nginx_reverse_proxy_block }}
-{% endif %}
 
 ## Support Info
 

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -257,6 +257,11 @@ services:
 {% endfor %}
 {% endif %}
     restart: unless-stopped{% else %}{{ custom_compose }}{% endif %}
+{% if external_application_snippet_enabled %}
+
+# This container requires an external application to be run separately to be run separately.
+{{ external_application_compose_block }}
+{% endif %}
 
 ```
 
@@ -394,6 +399,12 @@ docker run -d \
 {% endif %}
   --restart unless-stopped \
   lscr.io/{{ lsio_project_name_short }}/{{ project_name }}:{{ release_tag }}
+{% if external_application_snippet_enabled %}
+
+# This container requires an external application to be run separately.
+{{ external_application_cli_block }}
+{% endif %}
+
 ```
 
 {% if optional_block_1 %}

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -535,13 +535,6 @@ You only need to set the PUID and PGID variables if you are mounting the /config
 [![Docker Mods]({{ lsio_shieldsio_dynamic_mods }})]({{ lsio_mods_url }} "{{ lsio_mods_desc }}") [![Docker Universal Mods]({{ lsio_shieldsio_dynamic_universal_mods }})]({{ lsio_universal_mods_url }} "{{ lsio_universal_mods_desc }}")
 
 We publish various [Docker Mods]({{ lsio_github_url }}/docker-mods) to enable additional functionality within the containers. The list of Mods available for this image (if any) as well as universal mods that can be applied to any one of our images can be accessed via the dynamic badges above.
-{% if nginx_reverse_proxy_snippet_enabled %}
-
-## Reverse Proxy Snippet
-
-This snippet has been tested with {{ lsio_project_name|capitalize}}'s [Secure Web Application Gateway]({{ lsio_github_url }}/docker-swag) container.
-{{ nginx_reverse_proxy_block }}
-{% endif %}
 
 ## Support Info
 

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -91,8 +91,14 @@
 {# Set the WebUI link based on the link the CI runs against #}
     <TemplateURL>{{ "false" if unraid_template_sync is sameas false else "https://raw.githubusercontent.com/linuxserver/templates/main/unraid/" + project_name | lower + ".xml" }}</TemplateURL>
     <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver-ls-logo.png</Icon>
-{% if unraid_requirement is defined and unraid_requirement != "" %}
-    <Requires>{{ unraid_requirement }}</Requires>
+{% if (unraid_requirement is defined and unraid_requirement != "") or (external_application_snippet_enabled) %}
+    <Requires>
+        {{ unraid_requirement }}
+        {% if external_application_snippet_enabled %}
+        This container requires an external application to be run separately.
+        {{ external_application_unraid_block }}
+        {% endif %}
+    </Requires>
 {% endif %}
 {# Create changelog #}
 {% if changelogs is defined and changelogs %}

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -104,6 +104,11 @@ optional_block_1_items:
 app_setup_block_enabled: false
 app_setup_block: ""
 
+external_application_snippet_enabled: false
+external_application_cli_block: ""
+external_application_compose_block: ""
+external_application_unraid_block: ""
+
 # changelog
 changelogs:
   - { date: "09.12.17:", desc: "changes description" }

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -104,9 +104,9 @@ optional_block_1_items:
 app_setup_block_enabled: false
 app_setup_block: ""
 
-app_setup_nginx_reverse_proxy_snippet: false
-app_setup_nginx_reverse_proxy_block: ""
-# changelog
+nginx_reverse_proxy_snippet_enabled: false
+nginx_reverse_proxy_block: ""
 
+# changelog
 changelogs:
   - { date: "09.12.17:", desc: "changes description" }

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -104,9 +104,6 @@ optional_block_1_items:
 app_setup_block_enabled: false
 app_setup_block: ""
 
-nginx_reverse_proxy_snippet_enabled: false
-nginx_reverse_proxy_block: ""
-
 # changelog
 changelogs:
   - { date: "09.12.17:", desc: "changes description" }

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -84,8 +84,8 @@ opt_param_devices:
 opt_cap_add_param: false
 opt_cap_add_param_vars:
   - { cap_add_var: "NET_ADMIN" }
-security_opt_param: false
-security_opt_param_vars:
+opt_security_opt_param: false
+opt_security_opt_param_vars:
   - { run_var: "seccomp=unconfined", compose_var: "seccomp:unconfined", desc: "Disabled syscall filtering" }
 
 # Unraid templating


### PR DESCRIPTION
- Add `opt_` prefix on sec vars that were likely copy/pasted in a previous commit.
- Removing proxy snip. it was only actually used in one image (and one deprecated image). The proxy conf comments cover the information already.

