### PR TITLE
Add variables for external application snip/blocks

### DIFF
--- a/roles/generate-jenkins/defaults/main.yml
+++ b/roles/generate-jenkins/defaults/main.yml
@@ -45,10 +45,10 @@ opt_param_device_map: false
 opt_param_devices: []
 app_setup_block_enabled: false
 app_setup_block: ""
-external_database_snippet_enabled: false
-external_database_cli_block: ""
-external_database_compose_block: ""
-external_database_unraid_block: ""
+external_application_snippet_enabled: false
+external_application_cli_block: ""
+external_application_compose_block: ""
+external_application_unraid_block: ""
 optional_block_1: false
 changelogs: []
 custom_external_trigger: ""

--- a/roles/generate-jenkins/defaults/main.yml
+++ b/roles/generate-jenkins/defaults/main.yml
@@ -47,6 +47,10 @@ app_setup_block_enabled: false
 app_setup_block: ""
 nginx_reverse_proxy_snippet_enabled: false
 nginx_reverse_proxy_block: ""
+external_database_snippet_enabled: false
+external_database_cli_block: ""
+external_database_compose_block: ""
+external_database_unraid_block: ""
 optional_block_1: false
 changelogs: []
 custom_external_trigger: ""

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -240,6 +240,11 @@ services:
 {% endfor %}
 {% endif %}
     restart: unless-stopped{% else %}{{ custom_compose }}{% endif %}
+{% if external_database_snippet_enabled %}
+
+# This application requires an external database to be run separately.
+{{ external_database_compose_block }}
+{% endif %}
 
 ```
 
@@ -377,6 +382,12 @@ docker run -d \
 {% endif %}
   --restart unless-stopped \
   lscr.io/{{ lsio_project_name_short }}/{{ project_name }}:{{ release_tag }}
+{% if external_database_snippet_enabled %}
+
+# This application requires an external database to be run separately.
+{{ external_database_cli_block }}
+{% endif %}
+
 ```
 
 {% if optional_block_1 %}

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -240,10 +240,10 @@ services:
 {% endfor %}
 {% endif %}
     restart: unless-stopped{% else %}{{ custom_compose }}{% endif %}
-{% if external_database_snippet_enabled %}
+{% if external_application_snippet_enabled %}
 
-# This application requires an external database to be run separately.
-{{ external_database_compose_block }}
+# This container requires an external application to be run separately.
+{{ external_application_compose_block }}
 {% endif %}
 
 ```
@@ -382,10 +382,10 @@ docker run -d \
 {% endif %}
   --restart unless-stopped \
   lscr.io/{{ lsio_project_name_short }}/{{ project_name }}:{{ release_tag }}
-{% if external_database_snippet_enabled %}
+{% if external_application_snippet_enabled %}
 
-# This application requires an external database to be run separately.
-{{ external_database_cli_block }}
+# This container requires an external application to be run separately.
+{{ external_application_cli_block }}
 {% endif %}
 
 ```

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -257,6 +257,11 @@ services:
 {% endfor %}
 {% endif %}
     restart: unless-stopped{% else %}{{ custom_compose }}{% endif %}
+{% if external_database_snippet_enabled %}
+
+# This application requires an external database to be run separately to be run separately.
+{{ external_database_compose_block }}
+{% endif %}
 
 ```
 
@@ -394,6 +399,12 @@ docker run -d \
 {% endif %}
   --restart unless-stopped \
   lscr.io/{{ lsio_project_name_short }}/{{ project_name }}:{{ release_tag }}
+{% if external_database_snippet_enabled %}
+
+# This application requires an external database to be run separately.
+{{ external_database_cli_block }}
+{% endif %}
+
 ```
 
 {% if optional_block_1 %}

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -257,10 +257,10 @@ services:
 {% endfor %}
 {% endif %}
     restart: unless-stopped{% else %}{{ custom_compose }}{% endif %}
-{% if external_database_snippet_enabled %}
+{% if external_application_snippet_enabled %}
 
-# This application requires an external database to be run separately to be run separately.
-{{ external_database_compose_block }}
+# This container requires an external application to be run separately to be run separately.
+{{ external_application_compose_block }}
 {% endif %}
 
 ```
@@ -399,10 +399,10 @@ docker run -d \
 {% endif %}
   --restart unless-stopped \
   lscr.io/{{ lsio_project_name_short }}/{{ project_name }}:{{ release_tag }}
-{% if external_database_snippet_enabled %}
+{% if external_application_snippet_enabled %}
 
-# This application requires an external database to be run separately.
-{{ external_database_cli_block }}
+# This container requires an external application to be run separately.
+{{ external_application_cli_block }}
 {% endif %}
 
 ```

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -91,8 +91,14 @@
 {# Set the WebUI link based on the link the CI runs against #}
     <TemplateURL>{{ "false" if unraid_template_sync is sameas false else "https://raw.githubusercontent.com/linuxserver/templates/main/unraid/" + project_name | lower + ".xml" }}</TemplateURL>
     <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver-ls-logo.png</Icon>
-{% if unraid_requirement is defined and unraid_requirement != "" %}
-    <Requires>{{ unraid_requirement }}</Requires>
+{% if (unraid_requirement is defined and unraid_requirement != "") or (external_database_snippet_enabled) %}
+    <Requires>
+        {{ unraid_requirement }}
+        {% if external_database_snippet_enabled %}
+        This application requires an external database to be run separately.
+        {{ external_database_unraid_block }}
+        {% endif %}
+    </Requires>
 {% endif %}
 {# Create changelog #}
 {% if changelogs is defined and changelogs %}

--- a/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/UNRAID_TEMPLATE.j2
@@ -91,12 +91,12 @@
 {# Set the WebUI link based on the link the CI runs against #}
     <TemplateURL>{{ "false" if unraid_template_sync is sameas false else "https://raw.githubusercontent.com/linuxserver/templates/main/unraid/" + project_name | lower + ".xml" }}</TemplateURL>
     <Icon>https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver-ls-logo.png</Icon>
-{% if (unraid_requirement is defined and unraid_requirement != "") or (external_database_snippet_enabled) %}
+{% if (unraid_requirement is defined and unraid_requirement != "") or (external_application_snippet_enabled) %}
     <Requires>
         {{ unraid_requirement }}
-        {% if external_database_snippet_enabled %}
-        This application requires an external database to be run separately.
-        {{ external_database_unraid_block }}
+        {% if external_application_snippet_enabled %}
+        This container requires an external application to be run separately.
+        {{ external_application_unraid_block }}
         {% endif %}
     </Requires>
 {% endif %}

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -104,10 +104,10 @@ optional_block_1_items:
 app_setup_block_enabled: false
 app_setup_block: ""
 
-external_database_snippet_enabled: false
-external_database_cli_block: ""
-external_database_compose_block: ""
-external_database_unraid_block: ""
+external_application_snippet_enabled: false
+external_application_cli_block: ""
+external_application_compose_block: ""
+external_application_unraid_block: ""
 
 # changelog
 changelogs:

--- a/vars/_container-vars-blank
+++ b/vars/_container-vars-blank
@@ -107,6 +107,11 @@ app_setup_block: ""
 nginx_reverse_proxy_snippet_enabled: false
 nginx_reverse_proxy_block: ""
 
+external_database_snippet_enabled: false
+external_database_cli_block: ""
+external_database_compose_block: ""
+external_database_unraid_block: ""
+
 # changelog
 changelogs:
   - { date: "09.12.17:", desc: "changes description" }


### PR DESCRIPTION
@Roxedus plans to confirm the multi-line capability of the unraid template `<Requires>` tag.

This originally started with the intention of facilitating the ability to display the compse/cli information for running an external database, but it has evolved to be named generically "application" to foster inclusion of things like redis as well.