### PR TITLE
Replace package_versions with syft SBOM

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -781,26 +781,9 @@ pipeline {
               else
                 LOCAL_CONTAINER=${IMAGE}:${META_TAG}
               fi
-              if [ "${DIST_IMAGE}" == "alpine" ]; then
-                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  apk info -v > /tmp/package_versions.txt && \
-                  sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
-                  chmod 777 /tmp/package_versions.txt'
-              elif [ "${DIST_IMAGE}" == "ubuntu" ]; then
-                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  apt list -qq --installed | sed "s#/.*now ##g" | cut -d" " -f1 > /tmp/package_versions.txt && \
-                  sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
-                  chmod 777 /tmp/package_versions.txt'
-              elif [ "${DIST_IMAGE}" == "fedora" ]; then
-                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  rpm -qa > /tmp/package_versions.txt && \
-                  sort -o /tmp/package_versions.txt  /tmp/package_versions.txt && \
-                  chmod 777 /tmp/package_versions.txt'
-              elif [ "${DIST_IMAGE}" == "arch" ]; then
-                docker run --rm --entrypoint '/bin/sh' -v ${TEMPDIR}:/tmp ${LOCAL_CONTAINER} -c '\
-                  pacman -Q > /tmp/package_versions.txt && \
-                  chmod 777 /tmp/package_versions.txt'
-              fi
+              docker run --rm -v ${TEMPDIR}:/tmp anchore/syft:latest \
+                ${LOCAL_CONTAINER} -o table=/tmp/package_versions.txt
+              chmod 777 ${TEMPDIR}/package_versions.txt
               NEW_PACKAGE_TAG=$(md5sum ${TEMPDIR}/package_versions.txt | cut -c1-8 )
               echo "Package tag sha from current packages in buit container is ${NEW_PACKAGE_TAG} comparing to old ${PACKAGE_TAG} from github"
               if [ "${NEW_PACKAGE_TAG}" != "${PACKAGE_TAG}" ]; then

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -781,7 +781,7 @@ pipeline {
               else
                 LOCAL_CONTAINER=${IMAGE}:${META_TAG}
               fi
-              docker run --rm -v ${TEMPDIR}:/tmp anchore/syft:latest \
+              docker run --rm -v ${TEMPDIR}:/tmp ghcr.io/anchore/syft:latest \
                 ${LOCAL_CONTAINER} -o table=/tmp/package_versions.txt
               chmod 777 ${TEMPDIR}/package_versions.txt
               NEW_PACKAGE_TAG=$(md5sum ${TEMPDIR}/package_versions.txt | cut -c1-8 )

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -781,7 +781,10 @@ pipeline {
               else
                 LOCAL_CONTAINER=${IMAGE}:${META_TAG}
               fi
-              docker run --rm -v ${TEMPDIR}:/tmp ghcr.io/anchore/syft:latest \
+              docker run --rm \
+                -v /var/run/docker.sock:/var/run/docker.sock:ro \
+                -v ${TEMPDIR}:/tmp \
+                ghcr.io/anchore/syft:latest \
                 ${LOCAL_CONTAINER} -o table=/tmp/package_versions.txt
               chmod 777 ${TEMPDIR}/package_versions.txt
               NEW_PACKAGE_TAG=$(md5sum ${TEMPDIR}/package_versions.txt | cut -c1-8 )


### PR DESCRIPTION
Example output for this image (jenkins-builder):
```
NAME                    VERSION                TYPE   
Jinja2                  3.0.1                  python  
MarkupSafe              2.0.1                  python  
PyNaCl                  1.4.0                  python  
PyYAML                  5.4.1                  python  
alpine-baselayout       3.2.0-r18              apk     
alpine-keys             2.4-r1                 apk     
ansible                 4.8.0                  python  
ansible                 4.8.0-r0               apk     
ansible-core            2.11.6                 python  
ansible-core            2.11.6-r1              apk     
apk-tools               2.12.7-r3              apk     
asn1crypto              1.4.0                  python  
bash                    5.1.16-r0              apk     
bcrypt                  3.2.0                  python  
brotli-libs             1.0.9-r5               apk     
busybox                 1.34.1                 binary  
busybox                 1.34.1-r7              apk     
ca-certificates         20220614-r0            apk     
ca-certificates-bundle  20220614-r0            apk     
cffi                    1.14.5                 python  
coreutils               9.0-r2                 apk     
cryptography            3.3.2                  python  
curl                    7.80.0-r6              apk     
expat                   2.5.0-r0               apk     
gdbm                    1.22-r0                apk     
idna                    3.3                    python  
libacl                  2.2.53-r0              apk     
libattr                 2.5.1-r1               apk     
libbz2                  1.0.8-r1               apk     
libc-utils              0.7.2-r3               apk     
libcrypto1.1            1.1.1t-r1              apk     
libcurl                 7.80.0-r6              apk     
libffi                  3.4.2-r1               apk     
libgcc                  10.3.1_git20211027-r0  apk     
libintl                 0.21-r0                apk     
libproc                 3.3.17-r0              apk     
libretls                3.3.4-r3               apk     
libssl1.1               1.1.1t-r1              apk     
libstdc++               10.3.1_git20211027-r0  apk     
linux-pam               1.5.2-r0               apk     
mpdecimal               2.5.1-r1               apk     
musl                    1.2.2-r7               apk     
musl-utils              1.2.2-r7               apk     
ncurses-libs            6.3_p20211120-r1       apk     
ncurses-terminfo-base   6.3_p20211120-r1       apk     
nghttp2-libs            1.46.0-r0              apk     
packaging               20.9                   python  
paramiko                2.7.2                  python  
procps                  3.3.17-r0              apk     
py3-asn1                0.4.8-r1               apk     
py3-asn1crypto          1.4.0-r1               apk     
py3-bcrypt              3.2.0-r4               apk     
py3-cffi                1.14.5-r4              apk     
py3-cparser             2.20-r1                apk     
py3-cryptography        3.3.2-r3               apk     
py3-idna                3.3-r0                 apk     
py3-jinja2              3.0.1-r0               apk     
py3-markupsafe          2.0.1-r0               apk     
py3-packaging           20.9-r1                apk     
py3-paramiko            2.7.2-r1               apk     
py3-parsing             2.4.7-r2               apk     
py3-pynacl              1.4.0-r2               apk     
py3-resolvelib          0.5.2-r1               apk     
py3-six                 1.16.0-r0              apk     
py3-yaml                5.4.1.1-r1             apk     
pyasn1                  0.4.8                  python  
pycparser               2.20                   python  
pyparsing               2.4.7                  python  
python                  3.9.16                 binary  
python3                 3.9.16-r0              apk     
readline                8.1.1-r0               apk     
resolvelib              0.5.2                  python  
s6-ipcserver            2.11.0.0-r0            apk     
scanelf                 1.3.3-r0               apk     
shadow                  4.8.1-r1               apk     
six                     1.16.0                 python  
skalibs                 2.11.0.0-r0            apk     
sqlite-libs             3.36.0-r0              apk     
ssl_client              1.34.1-r7              apk     
tzdata                  2022f-r1               apk     
utmps                   0.1.0.3-r0             apk     
xz                      5.2.5-r1               apk     
xz-libs                 5.2.5-r1               apk     
yaml                    0.2.5-r0               apk     
zlib                    1.2.12-r3              apk     
```

Seems to be sorted alphabetically, with capital letters being sorted above lower case.