### PR TITLE
check other arch repos if alpine repo trigger

### DIFF
--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -127,6 +127,15 @@ jobs:
           if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
             echo "**** Version ${EXT_RELEASE} already pushed, exiting ****"
             exit 0
+{% if external_type == "alpine_repo" %}
+          elif [[ $(curl -sL "{{ better_vars.DIST_REPO }}aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% if build_armhf %} || [[ $(curl -sL "{{ better_vars.DIST_REPO }}armv7/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% endif %}; then
+            echo "**** New version ${EXT_RELEASE} found; but not all arch repos updated yet; exiting ****"
+            FAILURE_REASON="New version ${EXT_RELEASE} for {{ project_name }} tag {{ release_tag }} is detected, however not all arch repos are updated yet. Will try again later."
+            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+              "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
+              "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
+            exit 0
+{% endif %}
           elif [ $(curl -s {{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ project_repo_name }}/job/{{ ls_branch }}/lastBuild/api/json | jq -r '.building') == "true" ]; then
             echo "**** New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting ****"
             exit 0

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -127,7 +127,7 @@ jobs:
           if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
             echo "**** Version ${EXT_RELEASE} already pushed, exiting ****"
             exit 0
-{% if external_type == "alpine_repo" %}
+{% if external_type == "alpine_repo" and better_vars.MULTIARCH == 'true' %}
           elif [[ $(curl -sL "{{ better_vars.DIST_REPO }}aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% if build_armhf %} || [[ $(curl -sL "{{ better_vars.DIST_REPO }}armv7/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% endif %}; then
             echo "**** New version ${EXT_RELEASE} found; but not all arch repos updated yet; exiting ****"
             FAILURE_REASON="New version ${EXT_RELEASE} for {{ project_name }} tag {{ release_tag }} is detected, however not all arch repos are updated yet. Will try again later."


### PR DESCRIPTION
If the external trigger is alpine repo type and is multi-arch, it will check aarch64 and armv7 (if it's set to build armhf) repos to make sure they are also updated before triggering build