### PR TITLE
Monthly

### DIFF
--- a/.github/workflows/call_issue_pr_tracker.yml
+++ b/.github/workflows/call_issue_pr_tracker.yml
@@ -2,9 +2,11 @@ name: Issue & PR Tracker
 
 on:
   issues:
-    types: [opened,reopened,labeled,unlabeled]
+    types: [opened,reopened,labeled,unlabeled,closed]
   pull_request_target:
-    types: [opened,reopened,review_requested,review_request_removed,labeled,unlabeled]
+    types: [opened,reopened,review_requested,review_request_removed,labeled,unlabeled,closed]
+  pull_request_review:
+    types: [submitted,edited,dismissed]
 
 jobs:
   manage-project:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -677,8 +677,6 @@ pipeline {
                 -e WEB_SCREENSHOT=\"${CI_WEB}\" \
                 -e WEB_AUTH=\"${CI_AUTH}\" \
                 -e WEB_PATH=\"${CI_WEBPATH}\" \
-                -e DO_REGION="ams3" \
-                -e DO_BUCKET="lsio-ci" \
                 -t ghcr.io/linuxserver/ci:latest \
                 python3 test_build.py'''
         }
@@ -968,6 +966,7 @@ pipeline {
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
               -d "{\\"body\\": \\"I am a bot, here are the test results for this PR: \\n${CI_URL}\\n${SHELLCHECK_URL}\\n${table}\\"}"'''
+
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,10 +39,11 @@ pipeline {
     // Setup all the basic environment variables needed for the build
     stage("Set ENV Variables base"){
       steps{
+        sh '''docker pull quay.io/skopeo/stable:v1 || : '''
         script{
           env.EXIT_STATUS = ''
           env.LS_RELEASE = sh(
-            script: '''docker run --rm ghcr.io/linuxserver/alexeiled-skopeo sh -c 'skopeo inspect docker://docker.io/'${DOCKERHUB_IMAGE}':latest 2>/dev/null' | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
+            script: '''docker run --rm quay.io/skopeo/stable:v1 inspect docker://ghcr.io/${LS_USER}/${CONTAINER_NAME}:latest 2>/dev/null | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
             returnStdout: true).trim()
           env.LS_RELEASE_NOTES = sh(
             script: '''cat readme-vars.yml | awk -F \\" '/date: "[0-9][0-9].[0-9][0-9].[0-9][0-9]:/ {print $4;exit;}' | sed -E ':a;N;$!ba;s/\\r{0,1}\\n/\\\\n/g' ''',
@@ -649,6 +650,7 @@ pipeline {
         ]) {
           script{
             env.CI_URL = 'https://ci-tests.linuxserver.io/' + env.IMAGE + '/' + env.META_TAG + '/index.html'
+            env.CI_JSON_URL = 'https://ci-tests.linuxserver.io/' + env.IMAGE + '/' + env.META_TAG + '/report.json'
           }
           sh '''#! /bin/bash
                 set -e
@@ -906,8 +908,66 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
-        sh '''curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/issues/${PULL_REQUEST}/comments \
-        -d '{"body": "I am a bot, here are the test results for this PR: \\n'${CI_URL}' \\n'${SHELLCHECK_URL}'"}' '''
+        sh '''#! /bin/bash
+            # Function to retrieve JSON data from URL
+            get_json() {
+              local url="$1"
+              local response=$(curl -s "$url")
+              if [ $? -ne 0 ]; then
+                echo "Failed to retrieve JSON data from $url"
+                return 1
+              fi
+              local json=$(echo "$response" | jq .)
+              if [ $? -ne 0 ]; then
+                echo "Failed to parse JSON data from $url"
+                return 1
+              fi
+              echo "$json"
+            }
+
+            build_table() {
+              local data="$1"
+
+              # Get the keys in the JSON data
+              local keys=$(echo "$data" | jq -r 'to_entries | map(.key) | .[]')
+
+              # Check if keys are empty
+              if [ -z "$keys" ]; then
+                echo "JSON report data does not contain any keys or the report does not exist."
+                return 1
+              fi
+
+              # Build table header
+              local header="| Tag | Passed |\\n| --- | --- |\\n"
+
+              # Loop through the JSON data to build the table rows
+              local rows=""
+              for build in $keys; do
+                local status=$(echo "$data" | jq -r ".[\\"$build\\"].test_success")
+                if [ "$status" = "true" ]; then
+                  status="✅"
+                else
+                  status="❌"
+                fi
+                local row="| "$build" | "$status" |\\n"
+                rows="${rows}${row}"
+              done
+
+              local table="${header}${rows}"
+              local escaped_table=$(echo "$table" | sed 's/\"/\\\\"/g')
+              echo "$escaped_table"
+            }
+
+            # Retrieve JSON data from URL
+            data=$(get_json "$CI_JSON_URL")
+            # Create table from JSON data
+            table=$(build_table "$data")
+            echo -e "$table"
+
+            curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
+              -d "{\\"body\\": \\"I am a bot, here are the test results for this PR: \\n${CI_URL}\\n${SHELLCHECK_URL}\\n${table}\\"}"'''
       }
     }
   }

--- a/checkrun.sh
+++ b/checkrun.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# initialize variables
+ALL_SHELL_FILES=()
+EXECUTABLE_FILES=()
+MOUNT_OPTIONS=()
+NON_EXECUTABLE_FILES=()
+SHELLCHECK_ENTRYPOINT="/bin/shellcheck"
+SHELLCHECK_IMAGE="koalaman/shellcheck:stable"
+SHELLCHECK_OPTIONS=("--exclude=SC1008" "--format=checkstyle" "--shell=bash")
+SHELLCHECK_WORKDIR="/mnt"
+TEST_AREA=()
+
+# clear preexising checkstyle files
+echo "<?xml version='1.0' encoding='UTF-8'?><checkstyle version='4.3'></checkstyle>" >"${WORKSPACE}"/shellcheck-result.xml
+
+if [[ -d "${WORKSPACE}"/init ]]; then
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/init:${SHELLCHECK_WORKDIR}/init")
+    TEST_AREA+=("init")
+fi
+
+if [[ -d "${WORKSPACE}"/services ]]; then
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/services:${SHELLCHECK_WORKDIR}/services")
+    TEST_AREA+=("services")
+fi
+
+if [[ -d "${WORKSPACE}"/root/etc/cont-init.d ]]; then
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/cont-init.d:${SHELLCHECK_WORKDIR}/root/etc/cont-init.d")
+    TEST_AREA+=("root/etc/cont-init.d")
+fi
+
+if [[ -d "${WORKSPACE}"/root/etc/services.d ]]; then
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/services.d:${SHELLCHECK_WORKDIR}/root/etc/services.d")
+    TEST_AREA+=("root/etc/services.d")
+fi
+
+if [[ -d "${WORKSPACE}"/root/etc/s6-overlay/s6-rc.d ]]; then
+    MOUNT_OPTIONS+=("-v" "${WORKSPACE}/root/etc/s6-overlay/s6-rc.d:${SHELLCHECK_WORKDIR}/root/etc/s6-overlay/s6-rc.d")
+    TEST_AREA+=("root/etc/s6-overlay/s6-rc.d")
+fi
+
+# exit gracefully if no TEST_AREA are found
+if [[ ${#TEST_AREA[@]} -eq 0 ]]; then
+    echo "no common folders found, linting not required"
+    exit 0
+fi
+
+# check test area for executable files
+while IFS= read -r -d '' file; do
+    if head -n1 "${file}" | grep -q -E -w "sh|bash|dash|ksh"; then
+        ALL_SHELL_FILES+=("${file}")
+        if [[ -x "${file}" ]]; then
+            EXECUTABLE_FILES+=("${file}")
+        else
+            NON_EXECUTABLE_FILES+=("${file}")
+        fi
+    fi
+done < <(find "${TEST_AREA[@]}" -type f -print0)
+
+# exit with error if non executable shell scripts are found
+if [[ ${#NON_EXECUTABLE_FILES[@]} -ne 0 ]]; then
+    echo "the following shell scripts are not executable:"
+    printf "'%s'\n" "${NON_EXECUTABLE_FILES[@]}"
+    #exit 1 # errors for non executable files are reported by https://github.com/linuxserver/github-workflows/blob/v1/.github/workflows/init-svc-executable-permissions.yml
+fi
+
+# exit gracefully if no ALL_SHELL_FILES are found
+if [[ ${#ALL_SHELL_FILES[@]} -eq 0 ]]; then
+    echo "no common files found, linting not required"
+    exit 0
+fi
+
+# run shellcheck
+docker pull "${SHELLCHECK_IMAGE}"
+docker run --rm -t \
+    "${SHELLCHECK_IMAGE}" \
+    shellcheck --version
+find "${ALL_SHELL_FILES[@]}" -exec \
+    docker run --rm -t \
+    --entrypoint "${SHELLCHECK_ENTRYPOINT}" \
+    --workdir "${SHELLCHECK_WORKDIR}" \
+    "${MOUNT_OPTIONS[@]}" \
+    "${SHELLCHECK_IMAGE}" \
+    "${SHELLCHECK_OPTIONS[@]}" {} + \
+    >"${WORKSPACE}"/shellcheck-result.xml
+
+# exit gracefully
+exit 0

--- a/roles/generate-jenkins/templates/CALL_ISSUE_PR_TRACKER.j2
+++ b/roles/generate-jenkins/templates/CALL_ISSUE_PR_TRACKER.j2
@@ -2,9 +2,11 @@ name: Issue & PR Tracker
 
 on:
   issues:
-    types: [opened,reopened,labeled,unlabeled]
+    types: [opened,reopened,labeled,unlabeled,closed]
   pull_request_target:
-    types: [opened,reopened,review_requested,review_request_removed,labeled,unlabeled]
+    types: [opened,reopened,review_requested,review_request_removed,labeled,unlabeled,closed]
+  pull_request_review:
+    types: [submitted,edited,dismissed]
 
 jobs:
   manage-project:

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -22,9 +22,11 @@ jobs:
 {% if custom_version_command is defined or external_type != "os" %}
           if [ -n "${{ '{{' }} secrets.PAUSE_EXTERNAL_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }} {{ '}}' }}" ]; then
             echo "**** Github secret PAUSE_EXTERNAL_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }} is set; skipping trigger. ****"
+            echo "Github secret \`PAUSE_EXTERNAL_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }}\` is set; skipping trigger." >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
           echo "**** External trigger running off of {{ ls_branch }} branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }}\". ****"
+          echo "External trigger running off of {{ ls_branch }} branch. To disable this trigger, set a Github secret named \`PAUSE_EXTERNAL_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**** Retrieving external version ****"
 {% endif %}
 {% if custom_version_command is defined and 'api.github.com' in custom_version_command %}
@@ -67,6 +69,7 @@ jobs:
           EXT_RELEASE=$(curl -sL "https://pypi.python.org/pypi/{{ better_vars.EXT_PIP }}/json" |jq -r '. | .info.version')
 {% elif external_type == "os" %}
           echo "**** No external release, exiting ****"
+          echo "No external release, exiting" >> $GITHUB_STEP_SUMMARY
           exit 0
 {% endif %}
 {% if custom_version_command is defined or external_type != "os" %}
@@ -81,6 +84,7 @@ jobs:
           fi
           EXT_RELEASE=$(echo ${EXT_RELEASE} | sed 's/[~,%@+;:/]//g')
           echo "**** External version: ${EXT_RELEASE} ****"
+          echo "External version: ${EXT_RELEASE}" >> $GITHUB_STEP_SUMMARY
           echo "**** Retrieving last pushed version ****"
           image="{{ better_vars.LS_USER }}/{{ project_name }}"
           tag="{{ release_tag }}"
@@ -124,12 +128,15 @@ jobs:
             exit 1
           fi
           echo "**** Last pushed version: ${IMAGE_VERSION} ****"
+          echo "Last pushed version: ${IMAGE_VERSION}" >> $GITHUB_STEP_SUMMARY
           if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
             echo "**** Version ${EXT_RELEASE} already pushed, exiting ****"
+            echo "Version ${EXT_RELEASE} already pushed, exiting" >> $GITHUB_STEP_SUMMARY
             exit 0
 {% if external_type == "alpine_repo" and better_vars.MULTIARCH == 'true' %}
           elif [[ $(curl -sL "{{ better_vars.DIST_REPO }}aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% if build_armhf %} || [[ $(curl -sL "{{ better_vars.DIST_REPO }}armv7/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% endif %}; then
             echo "**** New version ${EXT_RELEASE} found; but not all arch repos updated yet; exiting ****"
+            echo "New version ${EXT_RELEASE} found; but not all arch repos updated yet; exiting" >> $GITHUB_STEP_SUMMARY
             FAILURE_REASON="New version ${EXT_RELEASE} for {{ project_name }} tag {{ release_tag }} is detected, however not all arch repos are updated yet. Will try again later."
             curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
               "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
@@ -138,14 +145,17 @@ jobs:
 {% endif %}
           elif [ $(curl -s {{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ project_repo_name }}/job/{{ ls_branch }}/lastBuild/api/json | jq -r '.building') == "true" ]; then
             echo "**** New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting ****"
+            echo "New version ${EXT_RELEASE} found; but there already seems to be an active build on Jenkins; exiting" >> $GITHUB_STEP_SUMMARY
             exit 0
 {% if external_trigger_delay_hours > 0 %}
           elif [[ $(( $(date +%s%3N) - $(curl -s {{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ project_repo_name }}/job/{{ ls_branch }}/lastBuild/api/json | jq -r '.timestamp')  )) -lt $(( {{ external_trigger_delay_hours }} * 3600000 )) ]]; then
             echo "**** New version ${EXT_RELEASE} found; but the last build was less than {{ external_trigger_delay_hours }} hours ago; skipping trigger ****"
+            echo "New version ${EXT_RELEASE} found; but the last build was less than {{ external_trigger_delay_hours }} hours ago; skipping trigger" >> $GITHUB_STEP_SUMMARY
             exit 0
 {% endif %}
           else
             echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build ****"
+            echo "New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Triggering new build" >> $GITHUB_STEP_SUMMARY
             response=$(curl -iX POST \
               {{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ project_repo_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=false \
               --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
@@ -155,6 +165,7 @@ jobs:
             buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
             buildurl="${buildurl%$'\r'}"
             echo "**** Jenkins job build url: ${buildurl} ****"
+            echo "Jenkins job build url: ${buildurl}" >> $GITHUB_STEP_SUMMARY
             echo "**** Attempting to change the Jenkins job description ****"
             curl -iX POST \
               "${buildurl}submitDescription" \

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
@@ -39,7 +39,7 @@ jobs:
                 echo "Skipping branch ${br} due to no external trigger workflow present." >> $GITHUB_STEP_SUMMARY
               fi
             else
-              echo "**** ${br} appears to be a dev branch; skipping trigger. ****"
-              echo "Skipping branch ${br} due to being detected as dev branch." >> $GITHUB_STEP_SUMMARY
+              echo "**** ${br} is either a dev branch, or has no external version; skipping trigger. ****"
+              echo "Skipping branch ${br} due to being detected as dev branch or having no external version." >> $GITHUB_STEP_SUMMARY
             fi
           done

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER_SCHEDULER.j2
@@ -2,7 +2,7 @@ name: External Trigger Scheduler
 
 on:
   schedule:
-    - cron:  '{{ ('docker-' + project_name + '-external')|hash('sha512')|regex_replace('[^0-9]+','')|truncate(2,True,'')|replace('6','0')|replace('7','1')|replace('8','3')|replace('9','5') }} * * * *'
+    - cron:  '{{ 60 | random(seed=(project_name + '-external-minute')) }} * * * *'
   workflow_dispatch:
 
 jobs:
@@ -17,18 +17,18 @@ jobs:
         run: |
           echo "**** Branches found: ****"
           git for-each-ref --format='%(refname:short)' refs/remotes
-          echo "**** Pulling the yq docker image ****"
-          docker pull ghcr.io/linuxserver/yq
           for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
           do
             br=$(echo "$br" | sed 's|origin/||g')
             echo "**** Evaluating branch ${br} ****"
-            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/{{ project_repo_name }}/${br}/jenkins-vars.yml \
-              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
-            if [ "$br" == "$ls_branch" ]; then
-              echo "**** Branch ${br} appears to be live; checking workflow. ****"
+            ls_jenkins_vars=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/{{ project_repo_name }}/${br}/jenkins-vars.yml)
+            ls_branch=$(echo "${ls_jenkins_vars}" | yq -r '.ls_branch')
+            ls_trigger=$(echo "${ls_jenkins_vars}" | yq -r '.external_type')
+            if [[ "${br}" == "${ls_branch}" ]] && [[ "${ls_trigger}" != "os" ]]; then
+              echo "**** Branch ${br} appears to be live and trigger is not os; checking workflow. ****"
               if curl -sfX GET https://raw.githubusercontent.com/linuxserver/{{ project_repo_name }}/${br}/.github/workflows/external_trigger.yml > /dev/null 2>&1; then
                 echo "**** Workflow exists. Triggering external trigger workflow for branch ${br} ****."
+                echo "Triggering external trigger workflow for branch ${br}" >> $GITHUB_STEP_SUMMARY
                 curl -iX POST \
                   -H "Authorization: token ${{ '{{' }} secrets.CR_PAT {{ '}}' }}" \
                   -H "Accept: application/vnd.github.v3+json" \
@@ -36,8 +36,10 @@ jobs:
                   https://api.github.com/repos/linuxserver/{{ project_repo_name }}/actions/workflows/external_trigger.yml/dispatches
               else
                 echo "**** Workflow doesn't exist; skipping trigger. ****"
+                echo "Skipping branch ${br} due to no external trigger workflow present." >> $GITHUB_STEP_SUMMARY
               fi
             else
               echo "**** ${br} appears to be a dev branch; skipping trigger. ****"
+              echo "Skipping branch ${br} due to being detected as dev branch." >> $GITHUB_STEP_SUMMARY
             fi
           done

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -406,7 +406,7 @@ pipeline {
           script{
             env.SHELLCHECK_URL = 'https://ci-tests.linuxserver.io/' + env.IMAGE + '/' + env.META_TAG + '/shellcheck-result.xml'
           }
-          sh '''curl -sL https://raw.githubusercontent.com/linuxserver/docker-shellcheck/master/checkrun.sh | /bin/bash'''
+          sh '''curl -sL https://raw.githubusercontent.com/linuxserver/docker-jenkins-builder/master/checkrun.sh | /bin/bash'''
           sh '''#! /bin/bash
                 docker run --rm \
                   -v ${WORKSPACE}:/mnt \

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -1298,15 +1298,16 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
-        TEMPDIR=$(mktemp -d)
-        mkdir -p ${TEMPDIR}/repo
-        git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/repo/${LS_REPO}
-        cd ${TEMPDIR}/repo/${LS_REPO}
-        git checkout -f {{ ls_branch }}
-        git rm Jenkinsfile
-        git commit -m 'Disabling future builds'
-        git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git --all
-        rm -Rf ${TEMPDIR}
+        sh '''#! /bin/bash
+          TEMPDIR=$(mktemp -d)
+          mkdir -p ${TEMPDIR}/repo
+          git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/repo/${LS_REPO}
+          cd ${TEMPDIR}/repo/${LS_REPO}
+          git checkout -f {{ ls_branch }}
+          git rm Jenkinsfile
+          git commit -m 'Disabling future builds'
+          git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git --all
+          rm -Rf ${TEMPDIR}'''
       }
     }
 {% endif %}

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -915,6 +915,7 @@ pipeline {
         ]) {
           script{
             env.CI_URL = 'https://ci-tests.linuxserver.io/' + env.IMAGE + '/' + env.META_TAG + '/index.html'
+            env.CI_JSON_URL = 'https://ci-tests.linuxserver.io/' + env.IMAGE + '/' + env.META_TAG + '/report.json'
           }
           sh '''#! /bin/bash
                 set -e
@@ -1306,8 +1307,67 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
-        sh '''curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/issues/${PULL_REQUEST}/comments \
-        -d '{"body": "I am a bot, here are the test results for this PR: \\n'${CI_URL}' \\n'${SHELLCHECK_URL}'"}' '''
+        sh '''#! /bin/bash
+            # Function to retrieve JSON data from URL
+            get_json() {
+              local url="$1"
+              local response=$(curl -s "$url")
+              if [ $? -ne 0 ]; then
+                echo "Failed to retrieve JSON data from $url"
+                return 1
+              fi
+              local json=$(echo "$response" | jq .)
+              if [ $? -ne 0 ]; then
+                echo "Failed to parse JSON data from $url"
+                return 1
+              fi
+              echo "$json"
+            }
+
+            build_table() {
+              local data="$1"
+
+              # Get the keys in the JSON data
+              local keys=$(echo "$data" | jq -r 'to_entries | map(.key) | .[]')
+
+              # Check if keys are empty
+              if [ -z "$keys" ]; then
+                echo "JSON report data does not contain any keys or the report does not exist."
+                return 1
+              fi
+
+              # Build table header
+              local header="| Tag | Passed |\\n| --- | --- |\\n"
+
+              # Loop through the JSON data to build the table rows
+              local rows=""
+              for build in $keys; do
+                local status=$(echo "$data" | jq -r ".[\\"$build\\"].test_success")
+                if [ "$status" = "true" ]; then
+                  status="✅"
+                else
+                  status="❌"
+                fi
+                local row="| "$build" | "$status" |\\n"
+                rows="${rows}${row}"
+              done
+
+              local table="${header}${rows}"
+              local escaped_table=$(echo "$table" | sed 's/\"/\\\\"/g')
+              echo "$escaped_table"
+            }
+
+            # Retrieve JSON data from URL
+            data=$(get_json "$CI_JSON_URL")
+            # Create table from JSON data
+            table=$(build_table "$data")
+            echo -e "$table"
+
+            curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
+              -d "{\\"body\\": \\"I am a bot, here are the test results for this PR: \\n${CI_URL}\\n${SHELLCHECK_URL}\\n${table}\\"}"'''
+
       }
     }
 {% if project_deprecation_status %}

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -25,10 +25,11 @@ pipeline {
     // Setup all the basic environment variables needed for the build
     stage("Set ENV Variables base"){
       steps{
+        sh '''docker pull quay.io/skopeo/stable:v1 || : '''
         script{
           env.EXIT_STATUS = ''
           env.LS_RELEASE = sh(
-            script: '''docker run --rm ghcr.io/linuxserver/alexeiled-skopeo sh -c 'skopeo inspect docker://docker.io/'${DOCKERHUB_IMAGE}':{{ release_tag }} 2>/dev/null' | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
+            script: '''docker run --rm quay.io/skopeo/stable:v1 inspect docker://ghcr.io/${LS_USER}/${CONTAINER_NAME}:{{ release_tag }} 2>/dev/null | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
             returnStdout: true).trim()
           env.LS_RELEASE_NOTES = sh(
             script: '''cat readme-vars.yml | awk -F \\" '/date: "[0-9][0-9].[0-9][0-9].[0-9][0-9]:/ {print $4;exit;}' | sed -E ':a;N;$!ba;s/\\r{0,1}\\n/\\\\n/g' ''',

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -577,6 +577,26 @@ pipeline {
         }
       }
     }
+    // If this is a {{ ls_branch }} build check the S6 service file perms
+    stage("Check S6 Service file Permissions"){
+      when {
+        branch "{{ ls_branch }}"
+        environment name: 'CHANGE_ID', value: ''
+        environment name: 'EXIT_STATUS', value: ''
+      }
+      steps {
+        script{
+          sh '''#! /bin/bash
+            WRONG_PERM=$(find ./  -path "./.git" -prune -o \\( -name "run" -o -name "finish" -o -name "check" \\) -not -perm -u=x,g=x,o=x -print)
+            if [[ -n "${WRONG_PERM}" ]]; then
+              echo "The following S6 service files are missing the executable bit; canceling the faulty build: ${WRONG_PERM}"
+              exit 1
+            else
+              echo "S6 service file perms look good."
+            fi '''
+        }
+      }
+    }
     /* #######################
            GitLab Mirroring
        ####################### */

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -946,8 +946,6 @@ pipeline {
                 -e WEB_SCREENSHOT=\"${CI_WEB}\" \
                 -e WEB_AUTH=\"${CI_AUTH}\" \
                 -e WEB_PATH=\"${CI_WEBPATH}\" \
-                -e DO_REGION="ams3" \
-                -e DO_BUCKET="lsio-ci" \
                 -t ghcr.io/linuxserver/ci:latest \
                 python3 test_build.py'''
         }

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -1113,6 +1113,11 @@ pipeline {
 {% endif %}
                       docker manifest annotate ${MANIFESTIMAGE}:${SEMVER} ${MANIFESTIMAGE}:arm64v8-${SEMVER} --os linux --arch arm64 --variant v8
                     fi
+{% if not build_armhf %}
+                    docker manifest push --purge ${MANIFESTIMAGE}:arm32v7-{{ release_tag }} || :
+                    docker manifest create ${MANIFESTIMAGE}:arm32v7-{{ release_tag }} ${MANIFESTIMAGE}:amd64-{{ release_tag }}
+                    docker manifest push --purge ${MANIFESTIMAGE}:arm32v7-{{ release_tag }}
+{% endif %}
                     docker manifest push --purge ${MANIFESTIMAGE}:{{ release_tag }}
                     docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG}{{ ' ' }}
                     docker manifest push --purge ${MANIFESTIMAGE}:${EXT_RELEASE_TAG}{{ ' ' }}

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER.j2
@@ -14,13 +14,16 @@ jobs:
         run: |
           if [ -n "${{ '{{' }} secrets.PAUSE_PACKAGE_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }} {{ '}}' }}" ]; then
             echo "**** Github secret PAUSE_PACKAGE_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }} is set; skipping trigger. ****"
+            echo "Github secret \`PAUSE_PACKAGE_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }}\` is set; skipping trigger." >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
           if [ $(curl -s {{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ project_repo_name }}/job/{{ ls_branch }}/lastBuild/api/json | jq -r '.building') == "true" ]; then
             echo "**** There already seems to be an active build on Jenkins; skipping package trigger ****"
+            echo "There already seems to be an active build on Jenkins; skipping package trigger" >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
           echo "**** Package trigger running off of {{ ls_branch }} branch. To disable, set a Github secret named \"PAUSE_PACKAGE_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }}\". ****"
+          echo "Package trigger running off of {{ ls_branch }} branch. To disable, set a Github secret named \`PAUSE_PACKAGE_TRIGGER_{{ project_name|upper|regex_replace('[^A-Z0-9_]','_') }}_{{ ls_branch|upper|regex_replace('[^A-Z0-9_]','_') }}\`" >> $GITHUB_STEP_SUMMARY
           response=$(curl -iX POST \
             {{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ project_repo_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=true \
             --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
@@ -30,6 +33,7 @@ jobs:
           buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
           buildurl="${buildurl%$'\r'}"
           echo "**** Jenkins job build url: ${buildurl} ****"
+          echo "Jenkins job build url: ${buildurl}" >> $GITHUB_STEP_SUMMARY
           echo "**** Attempting to change the Jenkins job description ****"
           curl -iX POST \
             "${buildurl}submitDescription" \

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
@@ -17,18 +17,16 @@ jobs:
         run: |
           echo "**** Branches found: ****"
           git for-each-ref --format='%(refname:short)' refs/remotes
-          echo "**** Pulling the yq docker image ****"
-          docker pull ghcr.io/linuxserver/yq
           for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
           do
             br=$(echo "$br" | sed 's|origin/||g')
             echo "**** Evaluating branch ${br} ****"
-            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/{{ project_repo_name }}/${br}/jenkins-vars.yml \
-              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
+            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/{{ project_repo_name }}/${br}/jenkins-vars.yml | yq -r '.ls_branch')
             if [ "${br}" == "${ls_branch}" ]; then
               echo "**** Branch ${br} appears to be live; checking workflow. ****"
               if curl -sfX GET https://raw.githubusercontent.com/linuxserver/{{ project_repo_name }}/${br}/.github/workflows/package_trigger.yml > /dev/null 2>&1; then
                 echo "**** Workflow exists. Triggering package trigger workflow for branch ${br}. ****"
+                echo "Triggering package trigger workflow for branch ${br}" >> $GITHUB_STEP_SUMMARY
                 triggered_branches="${triggered_branches}${br} "
                 curl -iX POST \
                   -H "Authorization: token ${{ '{{' }} secrets.CR_PAT {{ '}}' }}" \
@@ -38,9 +36,11 @@ jobs:
                 sleep 30
               else
                 echo "**** Workflow doesn't exist; skipping trigger. ****"
+                echo "Skipping branch ${br} due to no package trigger workflow present." >> $GITHUB_STEP_SUMMARY
               fi
             else
               echo "**** ${br} appears to be a dev branch; skipping trigger. ****"
+              echo "Skipping branch ${br} due to being detected as dev branch." >> $GITHUB_STEP_SUMMARY
             fi
           done
           echo "**** Package check build(s) triggered for branch(es): ${triggered_branches} ****"


### PR DESCRIPTION
- Switch to official skopeo container
- Handle issue-pr close and review submitted actions
- Run Jenkinsfile final deprecation step in shell
- The S6 permission checker Github workflow checks PRs, but initial commits and other pushes to a live branch aren't checked. This PR makes the Jenkins builder check the live branch pushes and if there are missing executable bits in S6 services, it fails the build, preventing a broken image push.
- Add a markdown table to the PR comment stage
- Overwrite old `arm32v7-latest` and `arm32v7-nightly`, etc. tags with fake manifest lists that result in `no matching manifest for linux/arm/v7 in the manifest list entries` when attempting to pull on armhf
- Removes old unused DO envs from the test stage
- Use github runners' yq
- Have external scheduler ignore os triggered branches
- Update external trigger scheduler to use Rox's fancy cron randomizer
- Add summary comments to external and package triggers and schedulers