### PR TITLE
check s6 service perms on live build, fail if wrong

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -577,6 +577,26 @@ pipeline {
         }
       }
     }
+    // If this is a {{ ls_branch }} build check the S6 service file perms
+    stage("Check S6 Service file Permissions"){
+      when {
+        branch "{{ ls_branch }}"
+        environment name: 'CHANGE_ID', value: ''
+        environment name: 'EXIT_STATUS', value: ''
+      }
+      steps {
+        script{
+          sh '''#! /bin/bash
+            WRONG_PERM=$(find ./  -path "./.git" -prune -o \\( -name "run" -o -name "finish" -o -name "check" \\) -not -perm -u=x,g=x,o=x -print)
+            if [[ -n "${WRONG_PERM}" ]]; then
+              echo "The following S6 service files are missing the executable bit; canceling the faulty build: ${WRONG_PERM}"
+              exit 1
+            else
+              echo "S6 service file perms look good."
+            fi '''
+        }
+      }
+    }
     /* #######################
            GitLab Mirroring
        ####################### */


### PR DESCRIPTION
The S6 permission checker Github workflow checks PRs, but initial commits and other pushes to a live branch aren't checked. This PR makes the Jenkins builder check the live branch pushes and if there are missing executable bits in S6 services, it fails the build, preventing a broken image push.