### PR TITLE
only push fake manifest if necessary

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -1114,9 +1114,16 @@ pipeline {
                       docker manifest annotate ${MANIFESTIMAGE}:${SEMVER} ${MANIFESTIMAGE}:arm64v8-${SEMVER} --os linux --arch arm64 --variant v8
                     fi
 {% if not build_armhf %}
-                    docker manifest push --purge ${MANIFESTIMAGE}:arm32v7-{{ release_tag }} || :
-                    docker manifest create ${MANIFESTIMAGE}:arm32v7-{{ release_tag }} ${MANIFESTIMAGE}:amd64-{{ release_tag }}
-                    docker manifest push --purge ${MANIFESTIMAGE}:arm32v7-{{ release_tag }}
+                    token=$(curl -sX GET "https://ghcr.io/token?scope=repository%3Alinuxserver%2F${CONTAINER_NAME}%3Apull" | jq -r '.token')
+                    digest=$(curl -s \
+                      --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+                      --header "Authorization: Bearer ${token}" \
+                      "https://ghcr.io/v2/linuxserver/${CONTAINER_NAME}/manifests/arm32v7-{{ release_tag }}")
+                    if [[ $(echo "$digest" | jq -r '.layers') != "null" ]]; then
+                      docker manifest push --purge ${MANIFESTIMAGE}:arm32v7-{{ release_tag }} || :
+                      docker manifest create ${MANIFESTIMAGE}:arm32v7-{{ release_tag }} ${MANIFESTIMAGE}:amd64-{{ release_tag }}
+                      docker manifest push --purge ${MANIFESTIMAGE}:arm32v7-{{ release_tag }}
+                    fi
 {% endif %}
                     docker manifest push --purge ${MANIFESTIMAGE}:{{ release_tag }}
                     docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG}{{ ' ' }}


### PR DESCRIPTION
If armhf is marked as deprecated, this PR will make the Jenkinsfile check the `arm32v7-releasetag` digest for the existence of `.layers`. If not `null`, it will push a fake multi arch manifest with just the `amd64-releasetag` image.
Possibilities covered:
- If no such image digest, jq returns `null`, no push (means we never pushed an arm32v7 image anyway, so no need to overwrite with a fake manifest)
- If image digest does not contain `.layers`, jq returns `null`, no push (means we already pushed a fake multiarch manifest)
- If image digest contains `.layers`, jq returns `not "null"` and it pushed (means we were previously pushing arm32v7 images

This logic utilizes the difference between single image digests and multi image manifests.

The single image digest contains info on image layers, whereas the multi image manifests contain info on the images contained  in the manifests, but not the layers. The regular `arm32v7-latest` tags are single image digests whereas the fake manifests we push after deprecation are multi image.