### PR TITLE
handle multi-arch correctly when skip_package_check is set

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -660,7 +660,7 @@ pipeline {
     stage('Build-Single') {
       when {
         expression {
-          env.MULTIARCH == 'false' || params.PACKAGE_CHECK == 'true'
+          env.MULTIARCH == 'false'{% if skip_package_check is not defined %} || params.PACKAGE_CHECK == 'true'{% endif +%}
         }
         environment name: 'EXIT_STATUS', value: ''
       }
@@ -691,7 +691,9 @@ pipeline {
       when {
         allOf {
           environment name: 'MULTIARCH', value: 'true'
+{% if skip_package_check is not defined %}
           expression { params.PACKAGE_CHECK == 'false' }
+{% endif %}
         }
         environment name: 'EXIT_STATUS', value: ''
       }


### PR DESCRIPTION
Rarely used `skip_package_check` option was breaking package check builds since switch to single arch building package check builds.
This PR fixes it so that when `skip_package_check` is set to `true`, the package check builds do single or multi arch solely based on the project's setting.

PS. `skip_package_check` is used for `FROM scratch` images that only contain binaries and libraries, without the OS, such as ffmpeg's bin branch. Since there are no OS packages in those images, a triggered package check will simply build and push the image without checking installed packages or exporting the `package_versions.txt`