### PR TITLE
fix formatting on required security vars

### DIFF
--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -300,7 +300,7 @@ docker run -d \
 {% endif %}
 {% if security_opt_param %}
 {% for item in security_opt_param_vars %}
-  --security-opt={{ item.run_var }} \
+  --security-opt {{ item.run_var }} \
 {% endfor %}
 {% endif %}
 {% if opt_security_opt_param %}
@@ -512,7 +512,7 @@ Docker images are configured using parameters passed at runtime (such as those a
 {% endif %}
 {% if security_opt_param %}
 {% for item in security_opt_param_vars %}
-| `--security-opt {{ item.run_security_opt_var }}` | {{ item.desc }} |
+| `--security-opt {{ item.run_var }}` | {{ item.desc }} |
 {% endfor %}
 {% endif %}
 {% if opt_security_opt_param %}

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -324,7 +324,7 @@ docker run -d \
 {% endif %}
 {% if security_opt_param %}
 {% for item in security_opt_param_vars %}
-  --security-opt={{ item.run_var }} \
+  --security-opt {{ item.run_var }} \
 {% endfor %}
 {% endif %}
 {% if opt_security_opt_param %}
@@ -506,7 +506,7 @@ Container images are configured using parameters passed at runtime (such as thos
 {% endif %}
 {% if security_opt_param %}
 {% for item in security_opt_param_vars %}
-| `--security-opt {{ item.run_security_opt_var }}` | {{ item.desc }} |
+| `--security-opt {{ item.run_var }}` | {{ item.desc }} |
 {% endfor %}
 {% endif %}
 {% if opt_security_opt_param %}


### PR DESCRIPTION
We have some syntax differences in the optional and non optional security vars. This gets them in sync and removes the need for a secondary definition of  `run_security_opt_var`