### PR TITLE
Fix rendering when Version Tags is enabled

### DIFF
--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -89,6 +89,7 @@ This image provides various versions that are available via tags. Please read th
 | {{ item.tag }} | ✅ | {{ item.desc }} |
 {% endif %}
 {% endfor %}
+
 {% endif %}
 {% if app_setup_block_enabled %}
 ## Application Setup


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jenkins-builder/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

For README files where `development_version` is true, the markdown that's produced has a mistake.

In noticed this mistake [in this linuxserver.io README](https://github.com/linuxserver/docker-unifi-controller/blob/c2865d7fd42f8bba1f9669cc3c6925ceb17d2425/README.md?plain=1#L61-L71)

But it's present in [all README files that have `Version Tags`](https://github.com/search?q=org%3Alinuxserver%20%22Version%20Tags%22%20path%3A%2F(%5E%7C%5C%2F)README%5C.md%24%2F&type=code)

When `Version Tags` is followed by `Application Setup` (or theoretically the `Usage` heading), since there's no newline between the `Version Tags` table and the next heading some Markdown renderers (like GitBook and GitHub's code highlighter) fail to render the table correctly. There should be a newline after a Markdown table's last row.

This PR adds that newline

Here's an example of how this renders on docs.linuxserver.io for one of the 42 linuxserver.io projects that are affected.

![malformed-markdown](https://github.com/linuxserver/docker-jenkins-builder/assets/1134034/993eaa57-3621-48a6-9221-5d64ba6aab70)

## Benefits of this PR and context:

Currently 42 of the linuxserver.io documentation pages render incorrectly on docs.linuxserver.io . This fix will correct all of those doc pages

## How Has This Been Tested?

I've not tested this

## Source / References:
