### PR TITLE
fix placeholder project_name

### DIFF
--- a/roles/generate-jenkins/templates/ISSUE_TEMPLATE.bug.j2
+++ b/roles/generate-jenkins/templates/ISSUE_TEMPLATE.bug.j2
@@ -79,10 +79,10 @@ body:
   - type: textarea
     attributes:
       description: |
-        Provide a full docker log, output of "docker logs {{ lsio_project_name }}"
+        Provide a full docker log, output of "docker logs {{ project_name }}"
       label: Container logs
       placeholder: |
-        Output of `docker logs {{ lsio_project_name }}`
+        Output of `docker logs {{ project_name }}`
       render: bash
     validations:
       required: true


### PR DESCRIPTION
(currently displays `linuxserver.io` instead of container name)