### PR TITLE
run jenkins-builder as local only, fix deprecation, hardcode for s6v3, restructure templating

### DIFF
--- a/roles/generate-jenkins/tasks/main.yml
+++ b/roles/generate-jenkins/tasks/main.yml
@@ -122,30 +122,10 @@
     owner: "abc"
     group: "abc"
 
-- name: detect whether image is v2 or v3
-  when:
-    - lookup('env', 'LOCAL') == "true"
-  stat:
-    path: "/tmp/root/etc/s6-overlay"
-  register: s6v3image
-
-- name: detect whether image is v2 or v3
-  when:
-    - lookup('env', 'LOCAL') != "true"
-  stat:
-    path: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay"
-  register: s6v3imageremote
-
-- name: Print a debug message
-  debug:
-    msg: "S6v3 image detected"
-  when: (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
-
 - name: create destination dir for generated 99-deprecation
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - s6v3image.stat.isdir is not defined and s6v3imageremote.stat.isdir is not defined
   file:
     path: "/tmp/root/etc/cont-init.d"
     state: directory
@@ -156,201 +136,182 @@
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - s6v3image.stat.isdir is not defined and s6v3imageremote.stat.isdir is not defined
   file:
     path: "jenkins/{{ project_repo_name }}/root/etc/cont-init.d"
     state: directory
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create dir for init-services/dependencies.d
+- name: deprecate - create dir for init-services/dependencies.d
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "/tmp/root/etc/s6-overlay/s6-rc.d/init-services/dependencies.d"
     state: directory
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create file for init-services/dependencies.d/init-deprecate
+- name: deprecate - create file for init-services/dependencies.d/init-deprecate
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "/tmp/root/etc/s6-overlay/s6-rc.d/init-services/dependencies.d/init-deprecate"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create dir for init-deprecate/dependencies.d
+- name: deprecate - create dir for init-deprecate/dependencies.d
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "/tmp/root/etc/s6-overlay/s6-rc.d/init-deprecate/dependencies.d"
     state: directory
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create file for init-deprecate/dependencies.d/init-config-end
+- name: deprecate - create file for init-deprecate/dependencies.d/init-config-end
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "/tmp/root/etc/s6-overlay/s6-rc.d/init-deprecate/dependencies.d/init-config-end"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create file for init-deprecate/type
+- name: deprecate - create file for init-deprecate/type
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "/tmp/root/etc/s6-overlay/s6-rc.d/init-deprecate/type"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - populate file for init-deprecate/type
+- name: deprecate - populate file for init-deprecate/type
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   copy:
     dest: "/tmp/root/etc/s6-overlay/s6-rc.d/init-deprecate/type"
     content: |
       oneshot
 
-- name: v3 deprecate - create file for init-deprecate/up
+- name: deprecate - create file for init-deprecate/up
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "/tmp/root/etc/s6-overlay/s6-rc.d/init-deprecate/up"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - populate file for init-deprecate/up
+- name: deprecate - populate file for init-deprecate/up
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   copy:
     dest: "/tmp/root/etc/s6-overlay/s6-rc.d/init-deprecate/up"
     content: |
       /etc/s6-overlay/s6-rc.d/init-deprecate/run
 
-- name: v3 deprecate - create file for user/contents.d/init-deprecate
+- name: deprecate - create file for user/contents.d/init-deprecate
   when:
     - lookup('env', 'LOCAL') == "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "/tmp/root/etc/s6-overlay/s6-rc.d/user/contents.d/init-deprecate"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create dir for init-services/dependencies.d
+- name: deprecate - create dir for init-services/dependencies.d
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/init-services/dependencies.d"
     state: directory
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create file for init-services/dependencies.d/init-deprecate
+- name: deprecate - create file for init-services/dependencies.d/init-deprecate
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/init-services/dependencies.d/init-deprecate"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create dir for init-deprecate/dependencies.d
+- name: deprecate - create dir for init-deprecate/dependencies.d
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/init-deprecate/dependencies.d"
     state: directory
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create file for init-deprecate/dependencies.d/init-config-end
+- name: deprecate - create file for init-deprecate/dependencies.d/init-config-end
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/init-deprecate/dependencies.d/init-config-end"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - create file for init-deprecate/type
+- name: deprecate - create file for init-deprecate/type
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/init-deprecate/type"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - populate file for init-deprecate/type
+- name: deprecate - populate file for init-deprecate/type
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   copy:
     dest: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/init-deprecate/type"
     content: |
       oneshot
 
-- name: v3 deprecate - create file for init-deprecate/up
+- name: deprecate - create file for init-deprecate/up
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/init-deprecate/up"
     state: touch
     owner: "abc"
     group: "abc"
 
-- name: v3 deprecate - populate file for init-deprecate/up
+- name: deprecate - populate file for init-deprecate/up
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   copy:
     dest: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/init-deprecate/up"
     content: |
       /etc/s6-overlay/s6-rc.d/init-deprecate/run
 
-- name: v3 deprecate - create file for user/contents.d/init-deprecate
+- name: deprecate - create file for user/contents.d/init-deprecate
   when:
     - lookup('env', 'LOCAL') != "true"
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   file:
     path: "jenkins/{{ project_repo_name }}/root/etc/s6-overlay/s6-rc.d/user/contents.d/init-deprecate"
     state: touch
@@ -555,12 +516,11 @@
 
 # Deprecation init script templating
 
-- name: write deprecation init script v3
+- name: write deprecation init script
   when:
     - lookup('env', 'LOCAL') != "true"
-    - item.deprecation is defined and item.deprecation == "v3"
+    - item.deprecation is defined
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   template:
     src: "../templates/{{ item.src }}"
     dest: "jenkins/{{ project_repo_name }}/{{ item.dest }}"
@@ -570,12 +530,11 @@
   delegate_to: localhost
   loop: "{{  templated_files  }}"
 
-- name: write deprecation init script local v3
+- name: write deprecation init script local
   when:
     - lookup('env', 'LOCAL') == "true"
-    - item.deprecation is defined and item.deprecation == "v3"
+    - item.deprecation is defined
     - project_deprecation_status == true
-    - (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir)
   template:
     src: "../templates/{{ item.src }}"
     dest: "/tmp/{{ item.dest }}"
@@ -585,33 +544,6 @@
   delegate_to: localhost
   loop: "{{  templated_files  }}"
 
-- name: write deprecation init script v2
-  when:
-    - lookup('env', 'LOCAL') != "true"
-    - item.deprecation is defined and item.deprecation == "v2"
-    - project_deprecation_status == true
-    - s6v3image.stat.isdir is not defined and s6v3imageremote.stat.isdir is not defined
-  template:
-    src: "../templates/{{ item.src }}"
-    dest: "jenkins/{{ project_repo_name }}/{{ item.dest }}"
-    owner: "abc"
-    group: "abc"
-  delegate_to: localhost
-  loop: "{{  templated_files  }}"
-
-- name: write deprecation init script local v2
-  when:
-    - lookup('env', 'LOCAL') == "true"
-    - item.deprecation is defined and item.deprecation == "v2"
-    - project_deprecation_status == true
-    - s6v3image.stat.isdir is not defined and s6v3imageremote.stat.isdir is not defined
-  template:
-    src: "../templates/{{ item.src }}"
-    dest: "/tmp/{{ item.dest }}"
-    owner: "abc"
-    group: "abc"
-  delegate_to: localhost
-  loop: "{{  templated_files  }}"
 
 # Unraid template templating
 

--- a/roles/generate-jenkins/templates.yml
+++ b/roles/generate-jenkins/templates.yml
@@ -1,8 +1,7 @@
 ---
 templated_files:
   - { src: '.editorconfig.j2', dest: '.editorconfig' }
-  - { src: '99-deprecation.j2', dest: 'root/etc/cont-init.d/99-deprecation', deprecation: 'v2' }
-  - { src: '99-deprecation.j2', dest: 'root/etc/s6-overlay/s6-rc.d/init-deprecate/run', deprecation: 'v3' }
+  - { src: '99-deprecation.j2', dest: 'root/etc/s6-overlay/s6-rc.d/init-deprecate/run', deprecation: 'true' }
   - { src: 'CONTRIBUTING.j2', dest: '.github/CONTRIBUTING.md' }
   - { src: 'DOCUMENTATION.j2', dest: '.jenkins-external/{{ project_repo_name }}.md' , readme: 'true' }
   - { src: 'DONATE.j2', dest: 'root/donate.txt' , donate: 'true' }

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -51,7 +51,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE .editorconfig ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE/config.yml ./.github/ISSUE_TEMPLATE/issue.bug.yml ./.github/ISSUE_TEMPLATE/issue.feature.yml ./.github/PULL_REQUEST_TEMPLATE.md{% if project_deprecation_status != true %} ./.github/workflows/external_trigger_scheduler.yml ./.github/workflows/greetings.yml ./.github/workflows/package_trigger_scheduler.yml ./.github/workflows/call_issue_pr_tracker.yml ./.github/workflows/call_issues_cron.yml ./.github/workflows/permissions.yml{% if custom_external_trigger != true %} ./.github/workflows/external_trigger.yml{% endif %}{% if custom_package_trigger != true %} ./.github/workflows/package_trigger.yml{% endif %}{% endif %}{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if project_deprecation_status %}{% if (s6v3image.stat.isdir is defined and s6v3image.stat.isdir) or (s6v3imageremote.stat.isdir is defined and s6v3imageremote.stat.isdir) %} ./root/etc/s6-overlay/s6-rc.d/init-deprecate/run ./root/etc/s6-overlay/s6-rc.d/init-deprecate/up ./root/etc/s6-overlay/s6-rc.d/init-deprecate/type ./root/etc/s6-overlay/s6-rc.d/init-deprecate/dependencies.d/init-config-end ./root/etc/s6-overlay/s6-rc.d/init-services/dependencies.d/init-deprecate ./root/etc/s6-overlay/s6-rc.d/user/contents.d/init-deprecate{% else %} ./root/etc/cont-init.d/99-deprecation{% endif %}{% endif %}'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE .editorconfig ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE/config.yml ./.github/ISSUE_TEMPLATE/issue.bug.yml ./.github/ISSUE_TEMPLATE/issue.feature.yml ./.github/PULL_REQUEST_TEMPLATE.md{% if project_deprecation_status != true %} ./.github/workflows/external_trigger_scheduler.yml ./.github/workflows/greetings.yml ./.github/workflows/package_trigger_scheduler.yml ./.github/workflows/call_issue_pr_tracker.yml ./.github/workflows/call_issues_cron.yml ./.github/workflows/permissions.yml{% if custom_external_trigger != true %} ./.github/workflows/external_trigger.yml{% endif %}{% if custom_package_trigger != true %} ./.github/workflows/package_trigger.yml{% endif %}{% endif %}{% if sponsor_links is defined %} ./root/donate.txt{% endif %}{% if project_deprecation_status %} ./root/etc/s6-overlay/s6-rc.d/init-deprecate/run ./root/etc/s6-overlay/s6-rc.d/init-deprecate/up ./root/etc/s6-overlay/s6-rc.d/init-deprecate/type ./root/etc/s6-overlay/s6-rc.d/init-deprecate/dependencies.d/init-config-end ./root/etc/s6-overlay/s6-rc.d/init-services/dependencies.d/init-deprecate ./root/etc/s6-overlay/s6-rc.d/user/contents.d/init-deprecate{% endif %}'
         }
         sh '''#! /bin/bash
               echo "The default github branch detected as ${GH_DEFAULT_BRANCH}" '''
@@ -447,7 +447,14 @@ pipeline {
 {% if project_repo_name != "docker-jenkins-builder" %}
               docker pull ghcr.io/linuxserver/jenkins-builder:latest
 {% endif %}
-              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH={{ ls_branch }} -v ${TEMPDIR}:/ansible/jenkins {% if project_repo_name != "docker-jenkins-builder" %}ghcr.io/linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}{{ ' ' }}
+              # Cloned repo paths for templating:
+              # ${TEMPDIR}/docker-${CONTAINER_NAME}: Cloned branch {{ ls_branch }} of ${LS_USER}/${LS_REPO} for running the jenkins builder on
+              # ${TEMPDIR}/repo/${LS_REPO}: Cloned branch {{ ls_branch }} of ${LS_USER}/${LS_REPO} for commiting various templated file changes and pushing back to Github
+              # ${TEMPDIR}/docs/docker-documentation: Cloned docs repo for pushing docs updates to Github
+              # ${TEMPDIR}/unraid/docker-templates: Cloned docker-templates repo to check for logos
+              # ${TEMPDIR}/unraid/templates: Cloned templates repo for commiting unraid template changes and pushing back to Github
+              git clone --branch {{ ls_branch }} --depth 1 https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/docker-${CONTAINER_NAME}
+              docker run --rm -v ${TEMPDIR}/docker-${CONTAINER_NAME}:/tmp -e LOCAL=true {% if project_repo_name != "docker-jenkins-builder" %}ghcr.io/linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}{{ ' ' }}
               # Stage 1 - Jenkinsfile update
               if [[ "$(md5sum Jenkinsfile | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/Jenkinsfile | awk '{ print $1 }')" ]]; then
                 mkdir -p ${TEMPDIR}/repo
@@ -507,14 +514,10 @@ pipeline {
                 mkdir -p ${TEMPDIR}/repo/${LS_REPO}/.github/workflows
                 mkdir -p ${TEMPDIR}/repo/${LS_REPO}/.github/ISSUE_TEMPLATE
 {% if project_deprecation_status %}
-                if [[ -d "${TEMPDIR}/repo/${LS_REPO}/root/etc/s6-overlay/s6-rc.d" ]]; then
-                  mkdir -p \
-                    ${TEMPDIR}/repo/${LS_REPO}/root/etc/s6-overlay/s6-rc.d/init-deprecate/dependencies.d \
-                    ${TEMPDIR}/repo/${LS_REPO}/root/etc/s6-overlay/s6-rc.d/init-services/dependencies.d \
-                    ${TEMPDIR}/repo/${LS_REPO}/root/etc/s6-overlay/s6-rc.d/user/contents.d
-                else
-                  mkdir -p ${TEMPDIR}/repo/${LS_REPO}/root/etc/cont-init.d
-                fi
+                mkdir -p \
+                  ${TEMPDIR}/repo/${LS_REPO}/root/etc/s6-overlay/s6-rc.d/init-deprecate/dependencies.d \
+                  ${TEMPDIR}/repo/${LS_REPO}/root/etc/s6-overlay/s6-rc.d/init-services/dependencies.d \
+                  ${TEMPDIR}/repo/${LS_REPO}/root/etc/s6-overlay/s6-rc.d/user/contents.d
 {% endif %}
                 cp --parents ${TEMPLATED_FILES} ${TEMPDIR}/repo/${LS_REPO}/ || :
                 cp --parents readme-vars.yml ${TEMPDIR}/repo/${LS_REPO}/ || :

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -455,7 +455,7 @@ pipeline {
               # ${TEMPDIR}/unraid/templates: Cloned templates repo for commiting unraid template changes and pushing back to Github
               git clone --branch {{ ls_branch }} --depth 1 https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/docker-${CONTAINER_NAME}
               docker run --rm -v ${TEMPDIR}/docker-${CONTAINER_NAME}:/tmp -e LOCAL=true {% if project_repo_name != "docker-jenkins-builder" %}ghcr.io/linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}{{ ' ' }}
-              # Stage 1 - Jenkinsfile update
+              echo "Starting Stage 1 - Jenkinsfile update"
               if [[ "$(md5sum Jenkinsfile | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/Jenkinsfile | awk '{ print $1 }')" ]]; then
                 mkdir -p ${TEMPDIR}/repo
                 git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/repo/${LS_REPO}
@@ -467,13 +467,13 @@ pipeline {
                 git pull https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git {{ ls_branch }}
                 git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git {{ ls_branch }}
                 echo "true" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
-                echo "Updating Jenkinsfile"
+                echo "Updating Jenkinsfile and exiting build, new one will trigger based on commit"
                 rm -Rf ${TEMPDIR}
                 exit 0
               else
                 echo "Jenkinsfile is up to date."
               fi
-              # Stage 2 - Delete old templates
+              echo "Starting Stage 2 - Delete old templates"
               OLD_TEMPLATES=".github/ISSUE_TEMPLATE.md .github/ISSUE_TEMPLATE/issue.bug.md .github/ISSUE_TEMPLATE/issue.feature.md .github/workflows/call_invalid_helper.yml .github/workflows/stale.yml{% if not build_armhf %} Dockerfile.armhf{% endif %}"
 {% if project_deprecation_status %}
               OLD_TEMPLATES="${OLD_TEMPLATES} $(echo .github/workflows/{external_trigger,external_trigger_scheduler,package_trigger,package_trigger_scheduler,call_issue_pr_tracker,call_issues_cron}.yml)"
@@ -495,13 +495,13 @@ pipeline {
                 git pull https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git {{ ls_branch }}
                 git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git {{ ls_branch }}
                 echo "true" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
-                echo "Deleting old and deprecated templates"
+                echo "Deleting old/deprecated templates and exiting build, new one will trigger based on commit"
                 rm -Rf ${TEMPDIR}
                 exit 0
               else
                 echo "No templates to delete"
               fi
-              # Stage 3 - Update templates
+              echo "Starting Stage 3 - Update templates"
               CURRENTHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
               cd ${TEMPDIR}/docker-${CONTAINER_NAME}
               NEWHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
@@ -531,9 +531,14 @@ pipeline {
                 git pull https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git {{ ls_branch }}
                 git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git {{ ls_branch }}
                 echo "true" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
+                echo "Updating templates and exiting build, new one will trigger based on commit"
+                rm -Rf ${TEMPDIR}
+                exit 0
               else
                 echo "false" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
+                echo "No templates to update"
               fi
+              echo "Starting Stage 4 - External repo updates: Docs, Unraid Template and Readme Sync to Docker Hub"
               mkdir -p ${TEMPDIR}/docs
               git clone https://github.com/linuxserver/docker-documentation.git ${TEMPDIR}/docs/docker-documentation
               if [[ "${BRANCH_NAME}" == "${GH_DEFAULT_BRANCH}"  ]] && [[ (! -f ${TEMPDIR}/docs/docker-documentation/docs/images/docker-${CONTAINER_NAME}.md) || ("$(md5sum ${TEMPDIR}/docs/docker-documentation/docs/images/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/.jenkins-external/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')") ]]; then
@@ -541,6 +546,7 @@ pipeline {
                 cd ${TEMPDIR}/docs/docker-documentation
                 GH_DOCS_DEFAULT_BRANCH=$(git remote show origin | grep "HEAD branch:" | sed 's|.*HEAD branch: ||')
                 git add docs/images/docker-${CONTAINER_NAME}.md
+                echo "Updating docs repo"
                 git commit -m 'Bot Updating Documentation'
 {% if project_deprecation_status %}
                 git mv docs/images/docker-${CONTAINER_NAME}.md docs/deprecated_images/docker-${CONTAINER_NAME}.md || :
@@ -551,6 +557,7 @@ pipeline {
                   chmod +x /usr/local/bin/yq
                 fi
                 if ! yq -e '.plugins.[].redirects.redirect_maps.[] | select(. == "deprecated/" + env(CONTAINER_NAME) + ".md")' mkdocs.yml  >/dev/null 2>&1; then
+                  echo "Updating mkdocs.yml with deprecation info"
                   yq -i '(.plugins.[] | select(.redirects)).redirects.redirect_maps |= . + {env(CONTAINER_NAME) + ".md" : "deprecated/" + env(CONTAINER_NAME) + ".md"}' mkdocs.yml
                   git add mkdocs.yml
                 fi
@@ -562,6 +569,8 @@ pipeline {
                   sleep $((RANDOM % MAXWAIT)) && \
                   git pull https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/docker-documentation.git ${GH_DOCS_DEFAULT_BRANCH} --rebase && \
                   git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/docker-documentation.git ${GH_DOCS_DEFAULT_BRANCH})
+              else
+                echo "Docs update not needed, skipping"
               fi
 {% if "jenkins-builder" not in project_name and "baseimage" not in project_name and full_custom_readme is not defined and unraid_template == true %}
               mkdir -p ${TEMPDIR}/unraid
@@ -573,6 +582,7 @@ pipeline {
                 sed -i "s|master/linuxserver.io/img/linuxserver-ls-logo.png|master/linuxserver.io/img/${CONTAINER_NAME}-icon.png|" ${TEMPDIR}/docker-${CONTAINER_NAME}/.jenkins-external/${CONTAINER_NAME}.xml
               fi
               if [[ "${BRANCH_NAME}" == "${GH_DEFAULT_BRANCH}" ]] && [[ (! -f ${TEMPDIR}/unraid/templates/unraid/${CONTAINER_NAME}.xml) || ("$(md5sum ${TEMPDIR}/unraid/templates/unraid/${CONTAINER_NAME}.xml | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/.jenkins-external/${CONTAINER_NAME}.xml | awk '{ print $1 }')") ]]; then
+                echo "Updating Unraid template"
                 cd ${TEMPDIR}/unraid/templates/
                 GH_TEMPLATES_DEFAULT_BRANCH=$(git remote show origin | grep "HEAD branch:" | sed 's|.*HEAD branch: ||')
 {% if project_deprecation_status %}
@@ -598,9 +608,10 @@ pipeline {
                   sleep $((RANDOM % MAXWAIT)) && \
                   git pull https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/templates.git ${GH_TEMPLATES_DEFAULT_BRANCH} --rebase && \
                   git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/linuxserver/templates.git ${GH_TEMPLATES_DEFAULT_BRANCH})
+              else
+                echo "No updates to Unraid template needed, skipping"
               fi
 {% endif %}
-              # Stage 4 - Sync Readme to Docker Hub
               if [[ "${BRANCH_NAME}" == "${GH_DEFAULT_BRANCH}" ]]; then
                 if [[ $(cat ${TEMPDIR}/docker-${CONTAINER_NAME}/README.md | wc -m) > 25000 ]]; then
                   echo "Readme is longer than 25,000 characters. Syncing the lite version to Docker Hub"


### PR DESCRIPTION
- Run jenkins-builder as local only (1st step to removing the remote run steps that double the number of tasks, consistent behavior between local and ci, much easier to test and troubleshoot) https://github.com/linuxserver/docker-jenkins-builder/commit/6a50b4f08b8d7c9dad154f77777e6395fe1ee1fb
  - Second step of removing the remote run steps would likely have to be done after all repos are updated otherwise jenkins build will fail running on an older Jenkinsfile. In such cases, a local update of templates pushed to github should fix it
- Fix deprecation (s6v2 vs s6v3 detection was working on a local run, but failing on remote. This PR hardcodes it to s6v3) https://github.com/linuxserver/docker-jenkins-builder/commit/6a50b4f08b8d7c9dad154f77777e6395fe1ee1fb
- Increase verbosity of templating steps https://github.com/linuxserver/docker-jenkins-builder/commit/0719f3e272b1694991f458d07a2db715296149df
- Slightly restructure templating to prevent a potential race condition by ensuring each commit to main repo results in an immediate build exit as the commit will trigger a new build and we don't want simultaneous builds running https://github.com/linuxserver/docker-jenkins-builder/commit/0719f3e272b1694991f458d07a2db715296149df