### PR TITLE
modify multi detection in package check

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -880,7 +880,7 @@ pipeline {
         sh '''#! /bin/bash
               set -e
               TEMPDIR=$(mktemp -d)
-              if [ "${MULTIARCH}" == "true" ] && [ "${PACKAGE_CHECK}" == "false" ]; then
+              if [ "${MULTIARCH}" == "true" ] && [ "${PACKAGE_CHECK}" != "true" ]; then
                 LOCAL_CONTAINER=${IMAGE}:amd64-${META_TAG}
               else
                 LOCAL_CONTAINER=${IMAGE}:${META_TAG}


### PR DESCRIPTION
Jenkins seems to have a weird bug that sometimes on a new branch push, the jenkins build parameter `PACKAGE_CHECK` does not get set as an env var in bash scripts, which causes a failure in our package update check. A replay of the same build strangely is not affected by the bug and succeeds.

Here's a failed first build: https://ci.linuxserver.io/blue/organizations/jenkins/Docker-Pipeline-Builders%2Fdocker-baseimage-rdesktop/detail/fedora-40/1/pipeline/
Here's a successful replay of the same build: https://ci.linuxserver.io/blue/organizations/jenkins/Docker-Pipeline-Builders%2Fdocker-baseimage-rdesktop/detail/fedora-40/2/pipeline

In the failed build, these lines: https://github.com/linuxserver/docker-baseimage-rdesktop/blob/214af71eac5442e9e1af06628304d28c851631ca/Jenkinsfile#L497-L500 are interpreted correctly and jenkins does a multi arch build. So we know that the jenkins param `PACKAGE_CHECK` is indeed set to `false`. However the following block has the test where we use the bash env var for the jenkins param: https://github.com/linuxserver/docker-baseimage-rdesktop/blob/214af71eac5442e9e1af06628304d28c851631ca/Jenkinsfile#L574 but this one does not succeed as the env var is not recognized to be set to `false` and syft incorrectly looks for the single arch build.

On a replay however, the bash env var for `PACKAGE_CHECK` is detected as set to `false` and syft successfully looks for the multi arch image.

This PR attempts to work around the jenkins bug by using `[ "${PACKAGE_CHECK}" != "true" ]` instead of `[ "${PACKAGE_CHECK}" == "false" ]` as the test. Since we only seem to experience this issue on new branch pushes, and that new branch pushes are always a commit triggered build and not a package check build, we shouldn't hit that jenkins bug anymore.

Also, this is the only spot in the whole Jenkinsfile where we rely on `PACKAGE_CHECK` being set as a bash env var.

PS. The param is supposed to be set to `false` by default here: https://github.com/linuxserver/docker-baseimage-rdesktop/blob/214af71eac5442e9e1af06628304d28c851631ca/Jenkinsfile#L10-L11