### PR TITLE
add optional ci test vars

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -994,8 +994,8 @@ pipeline {
 {% if repo_vars | select('regex', 'CI_WEB_SCREENSHOT_TIMEOUT') %}
                 -e WEB_SCREENSHOT_TIMEOUT=\"${CI_WEB_SCREENSHOT_TIMEOUT}\" \
 {% endif %}
-{% if repo_vars | select('regex', 'CI_SCREENSHOT_DELAY') %}
-                -e SCREENSHOT_DELAY=\"${CI_SCREENSHOT_DELAY}\" \
+{% if repo_vars | select('regex', 'CI_WEB_SCREENSHOT_DELAY') %}
+                -e WEB_SCREENSHOT_DELAY=\"${CI_WEB_SCREENSHOT_DELAY}\" \
 {% endif %}
 {% if repo_vars | select('regex', 'CI_DOCKER_LOGS_TIMEOUT') %}
                 -e DOCKER_LOGS_TIMEOUT=\"${CI_DOCKER_LOGS_TIMEOUT}\" \

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -988,7 +988,20 @@ pipeline {
                 --shm-size=1gb \
                 -v /var/run/docker.sock:/var/run/docker.sock \
                 -e IMAGE=\"${IMAGE}\" \
-                -e DELAY_START=\"${CI_DELAY}\" \
+{% if repo_vars | select('regex', 'CI_SBOM_TIMEOUT') %}
+                -e SBOM_TIMEOUT=\"${CI_SBOM_TIMEOUT}\" \
+{% endif %}
+{% if repo_vars | select('regex', 'CI_WEB_SCREENSHOT_TIMEOUT') %}
+                -e WEB_SCREENSHOT_TIMEOUT=\"${CI_WEB_SCREENSHOT_TIMEOUT}\" \
+{% endif %}
+{% if repo_vars | select('regex', 'CI_SCREENSHOT_DELAY') %}
+                -e SCREENSHOT_DELAY=\"${CI_SCREENSHOT_DELAY}\" \
+{% endif %}
+{% if repo_vars | select('regex', 'CI_DOCKER_LOGS_TIMEOUT') %}
+                -e DOCKER_LOGS_TIMEOUT=\"${CI_DOCKER_LOGS_TIMEOUT}\" \
+{% elif repo_vars | select('regex', 'CI_DELAY') %}
+                -e DOCKER_LOGS_TIMEOUT=\"${CI_DELAY}\" \
+{% endif %}
                 -e TAGS=\"${CI_TAGS}\" \
                 -e META_TAG=\"${META_TAG}\" \
                 -e PORT=\"${CI_PORT}\" \


### PR DESCRIPTION
Complements https://github.com/linuxserver/docker-ci/pull/35

Add new optional ci test vars:
- `CI_SBOM_TIMEOUT` (defaults to 900s)
- `CI_WEB_SCREENSHOT_TIMEOUT` (defaults to 120s)
- `CI_WEB_SCREENSHOT_DELAY` (defaults to 10s)
- `CI_DOCKER_LOGS_TIMEOUT` (defaults to `CI_DELAY` or 120s)