### PR TITLE
Change scarf link to generic URL

### DIFF
--- a/vars/common
+++ b/vars/common
@@ -30,7 +30,7 @@ project_deprecation_status: false
 project_github_asset: "{{ project_github_repo_url }}/blob/{{ ls_branch }}"
 project_github_repo_url: "{{ lsio_github_url }}/{{ project_repo_name }}"
 project_repo_name: "docker-{{ project_name }}"
-project_scarfio_url: "https://scarf.sh/gateway/{{ lsio_project_name_short }}-ci/docker/{{ lsio_project_name_short }}%2F{{ project_name }}"
+project_scarfio_url: "https://scarf.sh"
 
 # supported architectures
 arch_x86_64: "x86-64"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jenkins-builder/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
We can't link users to a publicly visible page for a given image so it makes more sense just to have a generic link to Scarf to make users aware of what it is. At least until/if they provide the option of public stats publishing.

In any case, the URL is wrong as they've changed the site layout, so it's now in the form

`https://app.scarf.sh/packages/linuxserver-ci/docker/linuxserver%2Fplex`

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
