### PR TITLE
Add read-only information to readme template

### DIFF
--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -38,7 +38,6 @@
 {% include "README_SNIPPETS/READONLY.j2" | trim %}
 
 {% endif %}
-
 {% if ["CI_SSL='true'", "CI_SSL= 'true'" ,"CI_SSL = 'true'"]|select("in", repo_vars) %}
 {% include "README_SNIPPETS/STRICT_PROXY.j2" | trim %}
 

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -34,6 +34,11 @@
 {% if app_setup_block_enabled %}
 {% include "README_SNIPPETS/APPLICATION_SETUP.j2" | trim %}
 
+{% if readonly_supported is defined and readonly_supported %}
+{% include "README_SNIPPETS/READONLY.j2" | trim %}
+
+{% endif %}
+
 {% if ["CI_SSL='true'", "CI_SSL= 'true'" ,"CI_SSL = 'true'"]|select("in", repo_vars) %}
 {% include "README_SNIPPETS/STRICT_PROXY.j2" | trim %}
 
@@ -136,6 +141,9 @@ Containers are configured using parameters passed at runtime (such as those abov
 {% for item in opt_security_opt_param_vars %}
 | `--security-opt {{ item.run_var }}` | {{ item.desc }} |
 {% endfor %}
+{% endif %}
+{% if readonly_supported is defined and readonly_supported %}
+| `--read-only=true` | Run container with a read-only filesystem. Please [read the docs](https://docs.linuxserver.io/misc/read-only/). |
 {% endif %}
 {% if cap_add_param or opt_cap_add_param or (custom_params is defined and 'sysctl' in (custom_params | map(attribute="name")) ) %}
 

--- a/roles/generate-jenkins/templates/README_SNIPPETS/READONLY.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/READONLY.j2
@@ -1,0 +1,8 @@
+## Read-Only Operation
+
+This image can be run with a read-only container filesystem. For details please [read the docs](https://docs.linuxserver.io/misc/read-only/).
+
+{% if readonly_message is defined %}
+### Caveats
+{{ readonly_message }}
+{% endif %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jenkins-builder/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
To invoke add to readme-vars

```yaml
readonly_supported: true
readonly_message: |
  Read-only operation is only possible in Server mode.
```

Adds after the end of the App Setup block with the other conditional snippets

Needs:
- https://github.com/linuxserver/docker-documentation/pull/229

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
