### PR TITLE
Adapt readme to Githubs alerts

### DIFF
--- a/filter_plugins/admonition.py
+++ b/filter_plugins/admonition.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+
+from ansible.module_utils.common.text.converters import to_native
+import re
+import sys
+
+
+class FilterModule(object):
+    def filters(self):
+        return {'admonition': self.admonition}
+
+    def admonition(self, text, flavour="gfm", severity:str = "note", collapse=None, title=None):
+        severities_flavours = {
+            "mkdocs": {
+                "abstract":"abstract",
+                "bug":"bug",
+                "danger":"danger",
+                "failure":"failure",
+                "info":"info",
+                "note":"note",
+                "question":"question",
+                "quote":"quote",
+                "success":"success",
+                "tip":"tip",
+                "warning":"warning",
+            }, # https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types
+            "gfm": {
+                "abstract":"NOTE",
+                "bug":"IMPORTANT",
+                "danger":"WARNING",
+                "failure":"CAUTION",
+                "info":"NOTE",
+                "note":"NOTE",
+                "question":"TIP",
+                "quote":"NOTE",
+                "success":"TIP",
+                "tip":"TIP",
+                "warning":"WARNING",
+            }, # https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts
+        }
+
+        flavour = flavour if flavour in severities_flavours.keys() else "gfm"
+
+        severities = severities_flavours.get(flavour)
+
+        note = ""
+
+
+        aa_severity = severity
+
+        if severity == "deprecation":
+            note = f"# DEPRECATION NOTICE \n{text}"
+        elif flavour == "gfm":
+            severity = severities.get(severity,"NOTE")
+            text = text.replace("\n", "\n>")
+            note = f">[!{severity}]\n>{text}"
+        elif flavour == "mkdocs":
+            severity = severities.get(severity, "note")
+            if collapse == None:
+                note = "!!!"
+            elif collapse:
+                note = "???+"
+            else:
+                note = "???"
+            note += f" {severity}"
+            note += f" \"{title}\"" if title else ""
+            text = text.replace("\n", "\n    ")
+            note += f"\n\n    {text}"
+
+        return note
+

--- a/filter_plugins/admonition.py
+++ b/filter_plugins/admonition.py
@@ -1,10 +1,5 @@
 #!/usr/bin/python
 
-from ansible.module_utils.common.text.converters import to_native
-import re
-import sys
-
-
 class FilterModule(object):
     def filters(self):
         return {'admonition': self.admonition}
@@ -44,7 +39,6 @@ class FilterModule(object):
         severities = severities_flavours.get(flavour)
 
         note = ""
-
 
         aa_severity = severity
 

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -1,5 +1,5 @@
 #jinja2: keep_trailing_newline:True
-{%- set output_format="!!! \\g<level> \\g<title>\n\n    \\g<message>" -%}
+{%- set markdown="mkdocs" -%}
 {% from 'common_macros.j2' import noter with context %}
 {%- set has_latest= true if (development_versions == true and 'latest' in (development_versions_items | map(attribute="tag"))) or (development_versions == false) else false -%}
 ---

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2-CUSTOM
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2-CUSTOM
@@ -1,5 +1,4 @@
-{%- set output_format="!!! \\g<level> \\g<title>\n\n    \\g<message>" -%}
-{% from 'common_macros.j2' import noter with context %}
+{%- set markdown="gfm" -%}
 ---
 title: {{ project_name }}
 ---

--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2-CUSTOM
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2-CUSTOM
@@ -1,4 +1,4 @@
-{%- set markdown="gfm" -%}
+{%- set markdown="mkdocs" -%}
 ---
 title: {{ project_name }}
 ---

--- a/roles/generate-jenkins/templates/ISSUE_TEMPLATE.bug.j2
+++ b/roles/generate-jenkins/templates/ISSUE_TEMPLATE.bug.j2
@@ -1,5 +1,4 @@
-{%- set output_format="# \\g<message>" -%}
-{% from 'common_macros.j2' import noter with context %}
+{%- set markdown="gfm" -%}
 # Based on the issue template
 name: Bug report
 description: Create a report to help us improve

--- a/roles/generate-jenkins/templates/ISSUE_TEMPLATE.feature.j2
+++ b/roles/generate-jenkins/templates/ISSUE_TEMPLATE.feature.j2
@@ -1,5 +1,4 @@
-{%- set output_format="# \\g<message>" -%}
-{% from 'common_macros.j2' import noter with context %}
+{%- set markdown="gfm" -%}
 # Based on the issue template
 name: Feature request
 description: Suggest an idea for this project

--- a/roles/generate-jenkins/templates/PULL_REQUEST_TEMPLATE.j2
+++ b/roles/generate-jenkins/templates/PULL_REQUEST_TEMPLATE.j2
@@ -1,5 +1,4 @@
-{%- set output_format="# \\g<message>" -%}
-{% from 'common_macros.j2' import noter with context %}
+{%- set markdown="gfm" -%}
 {% if project_deprecation_status %}
 {% include "README_SNIPPETS/DEPRECATION.j2" | trim %}
 

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -1,5 +1,5 @@
 #jinja2: keep_trailing_newline:True
-{%- set output_format="# \\g<message>" -%}
+{%- set markdown="gfm" -%}
 {% from 'common_macros.j2' import noter with context %}
 {%- set has_latest= true if (development_versions == true and 'latest' in (development_versions_items | map(attribute="tag"))) or (development_versions == false) else false -%}
 {% include "README_SNIPPETS/DO_NOT_EDIT.j2" | trim %}
@@ -9,8 +9,6 @@
 {% include "README_SNIPPETS/DEPRECATION.j2" | trim %}
 
 {% endif %}
-{%- set output_format="**\\g<level>**: \\g<message>" -%}
-{%- from 'common_macros.j2' import noter with context %}
 # [{{ lsio_project_name_short }}/{{ project_name }}]({{ project_github_repo_url }})
 
 {% include "README_SNIPPETS/PROJECT_BADGES.j2" | trim %}

--- a/roles/generate-jenkins/templates/README.j2-CUSTOM
+++ b/roles/generate-jenkins/templates/README.j2-CUSTOM
@@ -1,5 +1,4 @@
-{%- set output_format="# \\g<message>" -%}
-{% from 'common_macros.j2' import noter with context %}
+{%- set markdown="gfm" -%}
 {% include "README_SNIPPETS/DO_NOT_EDIT.j2" | trim %}
 
 {% if project_deprecation_status %}

--- a/roles/generate-jenkins/templates/README_SNIPPETS/DEPRECATION.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/DEPRECATION.j2
@@ -1,3 +1,3 @@
-{{ noter("?+warning[Deprecation warning](|This image is deprecated. We will not offer support for this image and it will not be updated.|)") }}
+{{ "This image is deprecated. We will not offer support for this image and it will not be updated." | admonition(flavour=markdown, severity="deprecation") }}
 
 {% if project_deprecation_message is defined %}{{ noter(project_deprecation_message) }}{% endif %}

--- a/roles/generate-jenkins/templates/README_SNIPPETS/MEDIA.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/MEDIA.j2
@@ -4,4 +4,4 @@ We have set /music and /downloads as optional paths, this is because it is the e
 
 Use the optional paths if you don't understand, or don't want hardlinks/atomic moves.
 
-{{  "The folks over at servarr.com wrote a good [write-up](https://wiki.servarr.com/docker-guide#consistent-and-well-planned-paths) on how to get started with this." | admonition(flavour=markdown, severity="tip", title="Well planned paths", collapse=True) }}
+{{  "The folks over at servarr.com wrote a good [write-up](https://wiki.servarr.com/docker-guide#consistent-and-well-planned-paths) on how to get started with this." | admonition(flavour=markdown, severity="tip", title="Well planned paths", collapse=False) }}

--- a/roles/generate-jenkins/templates/README_SNIPPETS/MEDIA.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/MEDIA.j2
@@ -4,4 +4,4 @@ We have set /music and /downloads as optional paths, this is because it is the e
 
 Use the optional paths if you don't understand, or don't want hardlinks/atomic moves.
 
-The folks over at servarr.com wrote a good [write-up](https://wiki.servarr.com/docker-guide#consistent-and-well-planned-paths) on how to get started with this.
+{{  "The folks over at servarr.com wrote a good [write-up](https://wiki.servarr.com/docker-guide#consistent-and-well-planned-paths) on how to get started with this." | admonition(flavour=markdown, severity="tip", title="Well planned paths", collapse=True) }}

--- a/roles/generate-jenkins/templates/README_SNIPPETS/UPDATING_INFO.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/UPDATING_INFO.j2
@@ -67,4 +67,4 @@ Below are the instructions for updating containers:
 
 ### Image Update Notifications - Diun (Docker Image Update Notifier)
 
-{{ noter("?+tip(|We recommend [Diun](https://crazymax.dev/diun/) for update notifications. Other tools that automatically update containers unattended are not recommended or supported.|)")}}
+{{  "We recommend [Diun](https://crazymax.dev/diun/) for update notifications. Other tools that automatically update containers unattended are not recommended or supported." | admonition(flavour=markdown, severity="tip") }}

--- a/roles/generate-jenkins/templates/common_macros.j2
+++ b/roles/generate-jenkins/templates/common_macros.j2
@@ -1,3 +1,11 @@
 {% macro noter(text) -%}
-{{ text | regex_replace('\?\+(?P<level>\w+)(?>\[(?P<title>[ \'\"\w]+)\])?\(\|(?P<message>.*)\|\)', output_format ) }}
+{% set ns = namespace(text=text) %}
+{% for match in (text | regex_findall('\?\+(?:\w+)(?:\[(?:[ \'\"\w]+)\])?\(\|(?:.*)\|\)')) %}
+{%- set match_obj=(match | regex_replace('\?\+(?P<severity>\w+)(?>\[(?P<title>[ \'\"\w]+)\])?\(\|(?P<message>.*)\|\)','{"message":"\g<message>", 
+"severity":"\g<severity>", "title":"\g<title>"}')) | from_json -%}
+{%- set match_result=match_obj.get("message") | admonition(flavour=markdown, severity=match_obj.get("severity"), title=match_obj.get("title")) -%}
+{%- set ns.text=(ns.text | replace(match, match_result)) -%}
+{% endfor %}
+
+{{ ns.text }}
 {%- endmacro %}

--- a/roles/generate-jenkins/templates/lite.j2
+++ b/roles/generate-jenkins/templates/lite.j2
@@ -1,11 +1,9 @@
-{%- set output_format="# \\g<message>" -%}
+{%- set markdown="gfm" -%}
 {% from 'common_macros.j2' import noter with context %}
 {% if project_deprecation_status %}
 {% include "README_SNIPPETS/DEPRECATION.j2" | trim %}
 
 {% endif %}
-{%- set output_format="**\\g<level>**: \\g<message>" -%}
-{%- from 'common_macros.j2' import noter with context %}
 # [{{ lsio_project_name_short }}/{{ project_name }}]({{ project_github_repo_url }})
 
 ## This readme has been truncated from the full version found [HERE]({{ project_github_repo_url }})

--- a/roles/generate-jenkins/templates/lite.j2-CUSTOM
+++ b/roles/generate-jenkins/templates/lite.j2-CUSTOM
@@ -1,5 +1,4 @@
-{%- set output_format="# \\g<message>" -%}
-{% from 'common_macros.j2' import noter with context %}
+{%- set markdown="gfm" -%}
 {% if project_deprecation_status %}
 {% include "README_SNIPPETS/DEPRECATION.j2" | trim %}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jenkins-builder/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

Adapt readme to Githubs [admonition syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).
- This is already supported on dockerhub, so readme sync can still use the same file.
- Gitlab is adapting this syntax down the road. 

The new admonition filter will map MkDocs' [types](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#supported-types) to Githubs few types. 

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
