### PR TITLE
add optional artifact check via `external_artifact_check` in jenkins_vars.yml

### DIFF
--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -169,7 +169,7 @@ jobs:
 {%- endif %}
             if [[ "${artifacts_found}" == "false" ]]; then
               echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
-              echo "> Not all artifacts are published yet, skipping trigger" >> $GITHUB_STEP_SUMMARY
+              echo "> New version detected, but not all artifacts are published yet; skipping trigger" >> $GITHUB_STEP_SUMMARY
               FAILURE_REASON="New version ${EXT_RELEASE} for {{ project_name }} tag {{ release_tag }} is detected, however not all artifacts are uploaded to upstream release yet. Will try again later."
               curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
                 "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],

--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -164,27 +164,42 @@ jobs:
             exit 0
 {% endif %}
           else
-            printf "\n## Trigger new build\n\n" >> $GITHUB_STEP_SUMMARY
-            echo "New version \`${EXT_RELEASE}\` found; old version was \`${IMAGE_VERSION}\`. Triggering new build" >> $GITHUB_STEP_SUMMARY
-            response=$(curl -iX POST \
-              {{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ project_repo_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=false \
-              --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
-            echo "Jenkins [job queue url](${response%$'\r'})" >> $GITHUB_STEP_SUMMARY
-            echo "Sleeping 10 seconds until job starts" >> $GITHUB_STEP_SUMMARY
-            sleep 10
-            buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
-            buildurl="${buildurl%$'\r'}"
-            echo "Jenkins job [build url](${buildurl})" >> $GITHUB_STEP_SUMMARY
-            echo "Attempting to change the Jenkins job description" >> $GITHUB_STEP_SUMMARY
-            curl -iX POST \
-              "${buildurl}submitDescription" \
-              --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }} \
-              --data-urlencode "description=GHA external trigger https://github.com/${{ '{{' }} github.repository {{ '}}' }}/actions/runs/${{ '{{' }} github.run_id {{ '}}' }}" \
-              --data-urlencode "Submit=Submit"
-            echo "**** Notifying Discord ****"
-            TRIGGER_REASON="A version change was detected for {{ project_name }} tag {{ release_tag }}. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE}"
-            curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
-              "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n**Build URL:** '"${buildurl}display/redirect"' \n"}],
-              "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
+{% if external_artifact_check %}
+            {{ external_artifact_check | indent(12)}}
+{%- endif %}
+            if [[ "${artifacts_found}" == "false" ]]; then
+              echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
+              echo "> Not all artifacts are published yet, skipping trigger" >> $GITHUB_STEP_SUMMARY
+              FAILURE_REASON="New version ${EXT_RELEASE} for {{ project_name }} tag {{ release_tag }} is detected, however not all artifacts are uploaded to upstream release yet. Will try again later."
+              curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+                "description": "**Trigger Failed** \n**Reason:** '"${FAILURE_REASON}"' \n"}],
+                "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
+            else
+              printf "\n## Trigger new build\n\n" >> $GITHUB_STEP_SUMMARY
+              echo "New version \`${EXT_RELEASE}\` found; old version was \`${IMAGE_VERSION}\`. Triggering new build" >> $GITHUB_STEP_SUMMARY
+              if "${artifacts_found}" == "true" ]]; then
+                echo "All artifacts seem to be uploaded." >> $GITHUB_STEP_SUMMARY
+              fi
+              response=$(curl -iX POST \
+                {{ lsio_ci_url }}/job/Docker-Pipeline-Builders/job/{{ project_repo_name }}/job/{{ ls_branch }}/buildWithParameters?PACKAGE_CHECK=false \
+                --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
+              echo "Jenkins [job queue url](${response%$'\r'})" >> $GITHUB_STEP_SUMMARY
+              echo "Sleeping 10 seconds until job starts" >> $GITHUB_STEP_SUMMARY
+              sleep 10
+              buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
+              buildurl="${buildurl%$'\r'}"
+              echo "Jenkins job [build url](${buildurl})" >> $GITHUB_STEP_SUMMARY
+              echo "Attempting to change the Jenkins job description" >> $GITHUB_STEP_SUMMARY
+              curl -iX POST \
+                "${buildurl}submitDescription" \
+                --user ${{ '{{' }} secrets.JENKINS_USER {{ '}}' }}:${{ '{{' }} secrets.JENKINS_TOKEN {{ '}}' }} \
+                --data-urlencode "description=GHA external trigger https://github.com/${{ '{{' }} github.repository {{ '}}' }}/actions/runs/${{ '{{' }} github.run_id {{ '}}' }}" \
+                --data-urlencode "Submit=Submit"
+              echo "**** Notifying Discord ****"
+              TRIGGER_REASON="A version change was detected for {{ project_name }} tag {{ release_tag }}. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE}"
+              curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+                "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n**Build URL:** '"${buildurl}display/redirect"' \n"}],
+                "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
+            fi
           fi
 {% endif %}


### PR DESCRIPTION
A few images use a custom external trigger to check for upstream artifacts before triggering a new build. However, once switched over to custom, the whole external trigger is manually managed and any update to the template requires manual updates to the custom ones.

This PR adds the external artifact check into the template, activated a new block var in jenkins-vars.yml named `external_artifact_check`.

This var can be set to any multiline bash commands (written in the jinja/ansible template style) and it will be injected into the external trigger.
The only requirement is that the var sets `artifacts_found` to either `true` or `false` depending on whatever check needs to be performed.

A sample var for Emby is as follows:
```yml
external_artifact_check: |
  assets=$(curl -u "${{ '{{' }} secrets.CR_USER {{ '}}' }}:${{ '{{' }} secrets.CR_PAT {{ '}}' }}" -sX GET "https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/tags/${EXT_RELEASE}" | jq -r '.assets[].browser_download_url')
  if grep -q "emby-server-deb_${EXT_RELEASE}_arm64.deb$" <<< "${assets}" && grep -q "emby-server-deb_${EXT_RELEASE}_amd64.deb$" <<< "${assets}"; then
    artifacts_found="true"
  else
    artifacts_found="false"
  fi
```
This block gets entered into the external trigger as shown here:
https://github.com/linuxserver/docker-emby/blob/bfa7d0bf3c127146ec5e7209cb6eadd5079b9952/.github/workflows/external_trigger.yml#L80-L85
As you can see, the github workflow variables such as `${{ secrets.CR_USER }}` need to be entered into jenkins-vars.yml as `${{ '{{' }} secrets.CR_USER {{ '}}' }}` because they go through jinja/ansible templating.

Here's the output of the test trigger: https://github.com/linuxserver/docker-emby/actions/runs/10725065218 (it was manually adjusted to force triggering even on the same version)
Here's the output of the test trigger with artifact check failed intentionally: https://github.com/linuxserver/docker-emby/actions/runs/10725987059