### PR TITLE
fix grep options and anchors

### DIFF
--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -23,7 +23,7 @@ jobs:
         run: |
           printf "# External trigger for {{ project_repo_name }}\n\n" >> $GITHUB_STEP_SUMMARY
 {% if custom_version_command is defined or external_type != "os" %}
-          if grep -wq "^{{ project_name }}_{{ ls_branch }}$" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
+          if grep -q "^{{ project_name }}_{{ ls_branch }}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
             echo "> Github organizational variable \`SKIP_EXTERNAL_TRIGGER\` contains \`{{ project_name }}_{{ ls_branch }}\`; skipping trigger." >> $GITHUB_STEP_SUMMARY
             exit 0

--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
@@ -33,7 +33,7 @@ jobs:
                 echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
                 echo "> Skipping branch ${br} due to \`skip_package_check\` being set in \`jenkins-vars.yml\`." >> $GITHUB_STEP_SUMMARY
                 skipped_branches="${skipped_branches}${br} "
-              elif grep -wq "^{{ project_name }}_${br}$" <<< "${SKIP_PACKAGE_TRIGGER}"; then
+              elif grep -q "^{{ project_name }}_${br}" <<< "${SKIP_PACKAGE_TRIGGER}"; then
                 echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
                 echo "> Github organizational variable \`SKIP_PACKAGE_TRIGGER\` contains \`{{ project_name }}_${br}\`; skipping trigger." >> $GITHUB_STEP_SUMMARY
                 skipped_branches="${skipped_branches}${br} "


### PR DESCRIPTION
Tested here: https://github.com/linuxserver/docker-baseimage-arch/actions/runs/11084778493/job/30800451959

- `grep -w` doesn't work with `-`
- While the front end anchor `^` works for all lines in the var, the rear end anchor `$` only works on the last line value