### PR TITLE
add a kasm blurb that can be used on all KasmVNC based images

### DIFF
--- a/roles/generate-jenkins/templates/DOCUMENTATION.j2
+++ b/roles/generate-jenkins/templates/DOCUMENTATION.j2
@@ -33,6 +33,10 @@ title: {{ project_name }}
 {% if app_setup_block_enabled %}
 {% include "README_SNIPPETS/APPLICATION_SETUP.j2" | trim %}
 
+{% if kasm_blurb is defined %}
+{% include "README_SNIPPETS/KASM.j2" | trim %}
+
+{% endif %}
 {% if readonly_supported is defined and readonly_supported %}
 {% include "README_SNIPPETS/READONLY.j2" | trim %}
 

--- a/roles/generate-jenkins/templates/README.j2
+++ b/roles/generate-jenkins/templates/README.j2
@@ -32,6 +32,10 @@
 {% if app_setup_block_enabled %}
 {% include "README_SNIPPETS/APPLICATION_SETUP.j2" | trim %}
 
+{% if kasm_blurb is defined %}
+{% include "README_SNIPPETS/KASM.j2" | trim %}
+
+{% endif %} 
 {% if readonly_supported is defined and readonly_supported %}
 {% include "README_SNIPPETS/READONLY.j2" | trim %}
 

--- a/roles/generate-jenkins/templates/README_SNIPPETS/KASM.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/KASM.j2
@@ -4,7 +4,7 @@
 
 **Do not put this on the Internet if you do not know what you are doing**
 
-By default this container has no authentication and the optional environment variables `CUSTOM_USER` and `PASSWORD` to enable basic http auth via the embedded NGINX server should only be used to locally secure the container from unwanted access on a local network. If exposing this to the Internet we recommend putting it behind [SWAG](https://github.com/linuxserver/docker-swag) or a similar secure authentication solution.
+By default this container has no authentication and the optional environment variables `CUSTOM_USER` and `PASSWORD` to enable basic http auth via the embedded NGINX server should only be used to locally secure the container from unwanted access on a local network. If exposing this to the Internet we recommend putting it behind a reverse proxy, such as [SWAG](https://github.com/linuxserver/docker-swag), and ensuring a secure authentication solution is in place.
 
 ### Options in all KasmVNC based GUI containers
 

--- a/roles/generate-jenkins/templates/README_SNIPPETS/KASM.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/KASM.j2
@@ -1,0 +1,127 @@
+**Modern GUI desktop apps have issues with the latest Docker and syscall compatibility, you can use Docker with the `--security-opt seccomp=unconfined` setting to allow these syscalls on hosts with older Kernels or libseccomp**
+
+### Security
+
+**Do not put this on the Internet if you do not know what you are doing**
+
+By default this container has no authentication and the optional environment variables `CUSTOM_USER` and `PASSWORD` to enable basic http auth via the embedded NGINX server should only be used to locally secure the container from unwanted access on a local network. If exposing this to the Internet we recommend putting it behind [SWAG](https://github.com/linuxserver/docker-swag) or a similar secure authentication solution.
+
+### Options in all KasmVNC based GUI containers
+
+This container is based on [Docker Baseimage KasmVNC](https://github.com/linuxserver/docker-baseimage-kasmvnc) which means there are additional environment variables and run configurations to enable or disable specific functionality.
+
+#### Optional environment variables
+
+| Variable | Description |
+| :----: | --- |
+| CUSTOM_PORT | Internal port the container listens on for http if it needs to be swapped from the default {% if external_http_port is defined %}{{ external_http_port }}{% else %}3000{% endif %}. |
+| CUSTOM_HTTPS_PORT | Internal port the container listens on for https if it needs to be swapped from the default {% if external_https_port is defined %}{{ external_https_port }}{% else %}3001{% endif %}. |
+| CUSTOM_USER | HTTP Basic auth username, abc is default. |
+| PASSWORD | HTTP Basic auth password, abc is default. If unset there will be no auth |
+| SUBFOLDER | Subfolder for the application if running a subfolder reverse proxy, need both slashes IE `/subfolder/` |
+| TITLE | The page title displayed on the web browser, default "KasmVNC Client". |
+| FM_HOME | This is the home directory (landing) for the file manager, default "/config". |
+| START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup. |
+| DRINODE | If mounting in /dev/dri for [DRI3 GPU Acceleration](https://www.kasmweb.com/kasmvnc/docs/master/gpu_acceleration.html) allows you to specify the device to use IE `/dev/dri/renderD128` |
+| DISABLE_IPV6 | If set to true or any value this will disable IPv6 | 
+| LC_ALL | Set the Language for the container to run as IE `fr_FR.UTF-8` `ar_AE.UTF-8` |
+| NO_DECOR | If set the application will run without window borders in openbox for use as a PWA. |
+| NO_FULL | Do not autmatically fullscreen applications when using openbox. |
+
+#### Optional run configurations
+
+| Variable | Description |
+| :----: | --- |
+| `--privileged` | Will start a Docker in Docker (DinD) setup inside the container to use docker in an isolated environment. For increased performance mount the Docker directory inside the container to the host IE `-v /home/user/docker-data:/var/lib/docker`. |
+| `-v /var/run/docker.sock:/var/run/docker.sock` | Mount in the host level Docker socket to either interact with it via CLI or use Docker enabled applications. |
+| `--device /dev/dri:/dev/dri` | Mount a GPU into the container, this can be used in conjunction with the `DRINODE` environment variable to leverage a host video card for GPU accelerated applications. Only **Open Source** drivers are supported IE (Intel,AMDGPU,Radeon,ATI,Nouveau) |
+
+### Language Support - Internationalization
+
+The environment variable `LC_ALL` can be used to start this container in a different language than English simply pass for example to launch the Desktop session in French `LC_ALL=fr_FR.UTF-8`. Some languages like Chinese, Japanese, or Korean will be missing fonts needed to render properly known as cjk fonts, but others may exist and not be installed inside the container depending on what underlying distribution you are running. We only ensure fonts for Latin characters are present. Fonts can be installed with a mod on startup.
+
+To install cjk fonts on startup as an example pass the environment variables (Alpine base):
+
+```
+-e DOCKER_MODS=linuxserver/mods:universal-package-install 
+-e INSTALL_PACKAGES={% if noto_fonts is defined %}{{ noto_fonts }}{% else %}font-noto-cjk{% endif %}
+-e LC_ALL=zh_CN.UTF-8
+```
+
+The web interface has the option for "IME Input Mode" in Settings which will allow non english characters to be used from a non en_US keyboard on the client. Once enabled it will perform the same as a local Linux installation set to your locale.
+
+### DRI3 GPU Acceleration
+
+For accelerated apps or games, render devices can be mounted into the container and leveraged by applications using:
+
+`--device /dev/dri:/dev/dri`
+
+This feature only supports **Open Source** GPU drivers:
+
+| Driver | Description |
+| :----: | --- |
+| Intel | i965 and i915 drivers for Intel iGPU chipsets |
+| AMD | AMDGPU, Radeon, and ATI drivers for AMD dedicated or APU chipsets |
+| NVIDIA | nouveau2 drivers only, closed source NVIDIA drivers lack DRI3 support |
+
+The `DRINODE` environment variable can be used to point to a specific GPU.
+Up to date information can be found [here](https://www.kasmweb.com/kasmvnc/docs/master/gpu_acceleration.html)
+
+{% if show_nvidia is defined %}### Nvidia GPU Support
+
+**Nvidia support is not compatible with Alpine based images as Alpine lacks Nvidia drivers**
+
+Nvidia support is available by leveraging Zink for OpenGL support. This can be enabled with the following run flags:
+
+| Variable | Description |
+| :----: | --- |
+| --gpus all | This can be filtered down but for most setups this will pass the one Nvidia GPU on the system |
+| --runtime nvidia | Specify the Nvidia runtime which mounts drivers and tools in from the host |
+
+The compose syntax is slightly different for this as you will need to set nvidia as the default runtime:
+
+```
+sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+sudo service docker restart
+```
+
+And to assign the GPU in compose:
+
+```
+services:
+  {{ project_name }}:
+    image: lscr.io/{{ lsio_project_name_short }}/{{ project_name }}:{{ release_tag }}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [compute,video,graphics,utility]
+```
+
+{% endif %}### Application management
+
+#### PRoot Apps
+
+If you run system native installations of software IE `sudo apt-get install filezilla` and then upgrade or destroy/re-create the container that software will be removed and the container will be at a clean state. For some users that will be acceptable and they can update their system packages as well using system native commands like `apt-get upgrade`. If you want Docker to handle upgrading the container and retain your applications and settings we have created [proot-apps](https://github.com/linuxserver/proot-apps) which allow portable applications to be installed to persistent storage in the user's `$HOME` directory and they will work in a confined Docker environment out of the box. These applications and their settings will persist upgrades of the base container and can be mounted into different flavors of KasmVNC based containers on the fly. This can be achieved from the command line with:
+
+```
+proot-apps install filezilla
+```
+
+PRoot Apps is included in all KasmVNC based containers, a list of linuxserver.io supported applications is located [HERE](https://github.com/linuxserver/proot-apps?tab=readme-ov-file#supported-apps).
+
+#### Native Apps
+
+It is possible to install extra packages during container start using [universal-package-install](https://github.com/linuxserver/docker-mods/tree/universal-package-install). It might increase starting time significantly. PRoot is preferred.
+
+```yaml
+  environment:
+    - DOCKER_MODS=linuxserver/mods:universal-package-install
+    - INSTALL_PACKAGES=libfuse2|git|gdb
+```
+
+### Lossless mode
+
+This container is capable of delivering a true lossless image at a high framerate to your web browser by changing the Stream Quality preset to "Lossless", more information [here](https://www.kasmweb.com/docs/latest/how_to/lossless.html#technical-background). In order to use this mode from a non localhost endpoint the HTTPS port on {% if external_https_port is defined %}{{ external_https_port }}{% else %}3001{% endif %} needs to be used. If using a reverse proxy to port {% if external_http_port is defined %}{{ external_http_port }}{% else %}3000{% endif %} specific headers will need to be set as outlined [here](https://github.com/linuxserver/docker-baseimage-kasmvnc#lossless).

--- a/roles/generate-jenkins/templates/README_SNIPPETS/KASM.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/KASM.j2
@@ -2,9 +2,9 @@
 
 ### Security
 
-**Do not put this on the Internet if you do not know what you are doing**
+{{ "Do not put this on the Internet if you do not know what you are doing." | admonition(flavour=markdown, severity="warning") }}
 
-By default this container has no authentication and the optional environment variables `CUSTOM_USER` and `PASSWORD` to enable basic http auth via the embedded NGINX server should only be used to locally secure the container from unwanted access on a local network. If exposing this to the Internet we recommend putting it behind a reverse proxy, such as [SWAG](https://github.com/linuxserver/docker-swag), and ensuring a secure authentication solution is in place.
+By default this container has no authentication and the optional environment variables `CUSTOM_USER` and `PASSWORD` to enable basic http auth via the embedded NGINX server should only be used to locally secure the container from unwanted access on a local network. If exposing this to the Internet we recommend putting it behind a reverse proxy, such as [SWAG](https://github.com/linuxserver/docker-swag), and ensuring a secure authentication solution is in place. From the web interface a terminal can be launched and it is configured for passwordless sudo, so anyone with access to it can install and run whatever they want along with probing your local network.
 
 ### Options in all KasmVNC based GUI containers
 


### PR DESCRIPTION
This can be setup to add information after the app setup block using the following variables: 

```
# kasm variables
kasm_blurb: true
external_http_port: "3000"
external_https_port: "3001"
noto_fonts: "font-noto-cjk"
show_nvidia: true
```

If only the `kasm_blurb: true` is set all defaults will be set as laid out here minus the nvidia support that needs to be specifically enabled for images that support it as Alpine does not. The Alpine blurb in the Nvidia section is to cover us for webtop or other images that may be multi distro base in the future. 

The ports are needed for images that are off the default 3000 and 3001, the maintainer will need to know what font noto package to use for their image base flavor here are the current packages: 

Arch: noto-fonts-cjk
Debian/Ubuntu: fonts-noto-cjk
Alpine: font-noto-cjk
Fedora: google-noto-cjk-fonts


IE for webtop the inline readme-vars.yml will look like this: 

```
# application setup block
app_setup_block_enabled: true
app_setup_block: |
  The Webtop can be accessed at:

  * http://yourhost:3000/
  * https://yourhost:3001/

# kasm variables
kasm_blurb: true
external_http_port: "3000"
external_https_port: "3001"
noto_fonts: "font-noto-cjk"
show_nvidia: true
```
