### PR TITLE
package trigger: print build url only if there are triggered branches

### DIFF
--- a/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
+++ b/roles/generate-jenkins/templates/PACKAGE_TRIGGER_SCHEDULER.j2
@@ -70,13 +70,14 @@ jobs:
           if [[ -n "${triggered_branches}" ]] || [[ -n "${skipped_branches}" ]]; then
             if [[ -n "${triggered_branches}" ]]; then
               NOTIFY_BRANCHES="**Triggered:** ${triggered_branches} \n"
+              NOTIFY_BUILD_URL="**Build URL:** {{ lsio_ci_url }}/blue/organizations/jenkins/Docker-Pipeline-Builders%2F{{ project_repo_name }}/activity/ \n"
+              echo "**** Package check build(s) triggered for branch(es): ${triggered_branches} ****"
             fi
             if [[ -n "${skipped_branches}" ]]; then
               NOTIFY_BRANCHES="${NOTIFY_BRANCHES}**Skipped:** ${skipped_branches} \n"
             fi
-            echo "**** Package check build(s) triggered for branch(es): ${triggered_branches} ****"
             echo "**** Notifying Discord ****"
             curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
-              "description": "**Package Check Build(s) Triggered for {{ project_name }}** \n'"${NOTIFY_BRANCHES}"'**Build URL:** '"{{ lsio_ci_url }}/blue/organizations/jenkins/Docker-Pipeline-Builders%2F{{ project_repo_name }}/activity/"' \n"}],
+              "description": "**Package Check Build(s) for {{ project_name }}** \n'"${NOTIFY_BRANCHES}"''"${NOTIFY_BUILD_URL}"'"}],
               "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
           fi


### PR DESCRIPTION
This PR modifies the discord notification for the package trigger so that the jenkins build url is only included if there are triggered builds. If all branches are skipped, the build url will be omitted.

Tests:
1. Synclounge master added to `SKIP_PACKAGE_TRIGGER` and package trigger initiated from manually updated `triggertest` branch
    - Action: https://github.com/linuxserver/docker-synclounge/actions/runs/11205332343
    - Discord notification: https://discord.com/channels/354974912613449730/400217715719274506/1292599616671584336
2. Synclounge master removed from SKIP_PACKAGE_TRIGGER` and package trigger initiated from manually updated `triggertest` branch
    - Action: https://github.com/linuxserver/docker-synclounge/actions/runs/11205338255
    - Discord notification: https://discord.com/channels/354974912613449730/400217715719274506/1292600054041018409