### PR TITLE
fix line break in language snippet and remove lossless notice

### DIFF
--- a/roles/generate-jenkins/templates/README_SNIPPETS/KASM.j2
+++ b/roles/generate-jenkins/templates/README_SNIPPETS/KASM.j2
@@ -45,6 +45,7 @@ To install cjk fonts on startup as an example pass the environment variables (Al
 ```
 -e DOCKER_MODS=linuxserver/mods:universal-package-install 
 -e INSTALL_PACKAGES={% if noto_fonts is defined %}{{ noto_fonts }}{% else %}font-noto-cjk{% endif %}
+
 -e LC_ALL=zh_CN.UTF-8
 ```
 
@@ -121,7 +122,3 @@ It is possible to install extra packages during container start using [universal
     - DOCKER_MODS=linuxserver/mods:universal-package-install
     - INSTALL_PACKAGES=libfuse2|git|gdb
 ```
-
-### Lossless mode
-
-This container is capable of delivering a true lossless image at a high framerate to your web browser by changing the Stream Quality preset to "Lossless", more information [here](https://www.kasmweb.com/docs/latest/how_to/lossless.html#technical-background). In order to use this mode from a non localhost endpoint the HTTPS port on {% if external_https_port is defined %}{{ external_https_port }}{% else %}3001{% endif %} needs to be used. If using a reverse proxy to port {% if external_http_port is defined %}{{ external_http_port }}{% else %}3000{% endif %} specific headers will need to be set as outlined [here](https://github.com/linuxserver/docker-baseimage-kasmvnc#lossless).


### PR DESCRIPTION
The lossless stuff no longer needs to be docced with this change https://github.com/kasmtech/noVNC/pull/119

Also need to fix a typo in the readme for the internationalization section, the line break does not work unless it is explicitly in there. 

Want to merge to master on this on as it is a bugfix and only a readme update that effects KasmVNC based images. 