### PR TITLE
Add init diagram to readme-vars.yml

### DIFF
--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -521,23 +521,36 @@ pipeline {
               else
                 echo "No templates to delete"
               fi
-              echo "Starting Stage 3 - Update templates"
 {% if full_custom_readme is not defined and (init_diagram is not defined or init_diagram) %}
-              if ! grep -q 'init_diagram:' ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml; then
+              echo "Starting Stage 2.5 - Update init diagram"
+              if ! grep -q 'init_diagram:' readme-vars.yml; then
                 echo "Adding the key 'init_diagram' to readme-vars.yml"
-                sed -i '\\|^#.*changelog.*$|d' ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml 
-                sed -i 's|^changelogs:|# init diagram\\ninit_diagram:\\n\\n# changelog\\nchangelogs:|' ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml
-                cp ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml ${TEMPDIR}/repo/${LS_REPO}/readme-vars.yml
+                sed -i '\\|^#.*changelog.*$|d' readme-vars.yml 
+                sed -i 's|^changelogs:|# init diagram\\ninit_diagram:\\n\\n# changelog\\nchangelogs:|' readme-vars.yml
               fi
-              docker run -d --rm -v /tmp/d2:/output -e PUID=$(id -u) -e PGID=$(id -g) ghcr.io/linuxserver/d2-builder:latest ${CONTAINER_NAME}:{{ ls_branch }}
-              yq -ei '.init_diagram |= load_str("/tmp/d2/${CONTAINER_NAME}-{{ ls_branch }}.d2")' ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml
-              if [[ $(grep -hs ^ ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml | md5sum | cut -c1-8) != $(grep -hs ^ ${TEMPDIR}/repo/${LS_REPO}/readme-vars.yml | md5sum | cut -c1-8) ]]; then
-                echo "'init_diagram' has been updated. Re-running jenkins builder."
-                docker run --rm -v ${TEMPDIR}/docker-${CONTAINER_NAME}:/tmp -e LOCAL=true -e PUID=$(id -u) -e PGID=$(id -g) {% if project_repo_name != "docker-jenkins-builder" %}ghcr.io/linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}{{ ' ' }}
-                cp ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml ${TEMPDIR}/repo/${LS_REPO}/readme-vars.yml
+              docker run -d --rm -v ${TEMPDIR}/d2:/output -e PUID=$(id -u) -e PGID=$(id -g) ghcr.io/linuxserver/d2-builder:latest ${CONTAINER_NAME}:{{ ls_branch }}
+              yq -ei '.init_diagram |= load_str("${TEMPDIR}/d2/${CONTAINER_NAME}-{{ ls_branch }}.d2")' readme-vars.yml || :
+              if [[ $(grep -hs ^ readme-vars.yml | md5sum | cut -c1-8) != $(grep -hs ^ ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml | md5sum | cut -c1-8) ]]; then
+                echo "'init_diagram' has been updated. Updating repo and exiting build, new one will trigger based on commit."
+                mkdir -p ${TEMPDIR}/repo
+                git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/repo/${LS_REPO}
+                cd ${TEMPDIR}/repo/${LS_REPO}
+                git checkout -f {{ ls_branch }}
+                cp ${WORKSPACE}/readme-vars.yml ${TEMPDIR}/repo/${LS_REPO}/readme-vars.yml
+                git add readme-vars.yml
+                git commit -m 'Bot Updating Templated Files'
+                git pull https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git {{ ls_branch }}
+                git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git {{ ls_branch }}
+                echo "true" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
+                echo "Updating templates and exiting build, new one will trigger based on commit"
+                rm -Rf ${TEMPDIR}
+                exit 0
+              else
+                echo "false" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
+                echo "Init diagram is unchanged"
               fi
-              rm -rf /tmp/d2
 {% endif %}
+              echo "Starting Stage 3 - Update templates"
               CURRENTHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
               cd ${TEMPDIR}/docker-${CONTAINER_NAME}
               NEWHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -528,9 +528,10 @@ pipeline {
                 sed -i '\\|^#.*changelog.*$|d' readme-vars.yml 
                 sed -i 's|^changelogs:|# init diagram\\ninit_diagram:\\n\\n# changelog\\nchangelogs:|' readme-vars.yml
               fi
-              docker run -d --rm -v ${TEMPDIR}/d2:/output -e PUID=$(id -u) -e PGID=$(id -g) ghcr.io/linuxserver/d2-builder:latest ${CONTAINER_NAME}:{{ release_tag }}
-              yq -ei ".init_diagram |= load_str(\\"${TEMPDIR}/d2/${CONTAINER_NAME}-{{ ls_branch }}.d2\\")" readme-vars.yml || :
-              if [[ $(grep -hs ^ readme-vars.yml | md5sum | cut -c1-8) != $(grep -hs ^ ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml | md5sum | cut -c1-8) ]]; then
+              mkdir -p ${TEMPDIR}/d2
+              docker run -d --rm -v ${TEMPDIR}/d2:/output -e PUID=$(id -u) -e PGID=$(id -g) -e RAW="true" ghcr.io/linuxserver/d2-builder:latest ${CONTAINER_NAME}:{{ release_tag }}
+              yq -ei ".init_diagram |= load_str(\\"${TEMPDIR}/d2/${CONTAINER_NAME}-{{ release_tag }}.d2\\")" readme-vars.yml || :
+              if [[ $(md5sum readme-vars.yml | cut -c1-8) != $(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml | cut -c1-8) ]]; then
                 echo "'init_diagram' has been updated. Updating repo and exiting build, new one will trigger based on commit."
                 mkdir -p ${TEMPDIR}/repo
                 git clone https://github.com/${LS_USER}/${LS_REPO}.git ${TEMPDIR}/repo/${LS_REPO}

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -522,6 +522,22 @@ pipeline {
                 echo "No templates to delete"
               fi
               echo "Starting Stage 3 - Update templates"
+{% if full_custom_readme is not defined and (init_diagram is not defined or init_diagram) %}
+              if ! grep -q 'init_diagram:' ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml; then
+                echo "Adding the key 'init_diagram' to readme-vars.yml"
+                sed -i '\\|^#.*changelog.*$|d' ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml 
+                sed -i 's|^changelogs:|# init diagram\\ninit_diagram:\\n\\n# changelog\\nchangelogs:|' ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml
+                cp ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml ${TEMPDIR}/repo/${LS_REPO}/readme-vars.yml
+              fi
+              docker run -d --rm -v /tmp/d2:/output -e PUID=$(id -u) -e PGID=$(id -g) ghcr.io/linuxserver/d2-builder:latest ${CONTAINER_NAME}:{{ ls_branch }}
+              yq -ei '.init_diagram |= load_str("/tmp/d2/${CONTAINER_NAME}-{{ ls_branch }}.d2")' ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml
+              if [[ $(grep -hs ^ ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml | md5sum | cut -c1-8) != $(grep -hs ^ ${TEMPDIR}/repo/${LS_REPO}/readme-vars.yml | md5sum | cut -c1-8) ]]; then
+                echo "'init_diagram' has been updated. Re-running jenkins builder."
+                docker run --rm -v ${TEMPDIR}/docker-${CONTAINER_NAME}:/tmp -e LOCAL=true -e PUID=$(id -u) -e PGID=$(id -g) {% if project_repo_name != "docker-jenkins-builder" %}ghcr.io/linuxserver/jenkins-builder:latest{% else %}jenkinslocal:${COMMIT_SHA}-${BUILD_NUMBER}{% endif %}{{ ' ' }}
+                cp ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml ${TEMPDIR}/repo/${LS_REPO}/readme-vars.yml
+              fi
+              rm -rf /tmp/d2
+{% endif %}
               CURRENTHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
               cd ${TEMPDIR}/docker-${CONTAINER_NAME}
               NEWHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)

--- a/roles/generate-jenkins/templates/Jenkinsfile.j2
+++ b/roles/generate-jenkins/templates/Jenkinsfile.j2
@@ -528,8 +528,8 @@ pipeline {
                 sed -i '\\|^#.*changelog.*$|d' readme-vars.yml 
                 sed -i 's|^changelogs:|# init diagram\\ninit_diagram:\\n\\n# changelog\\nchangelogs:|' readme-vars.yml
               fi
-              docker run -d --rm -v ${TEMPDIR}/d2:/output -e PUID=$(id -u) -e PGID=$(id -g) ghcr.io/linuxserver/d2-builder:latest ${CONTAINER_NAME}:{{ ls_branch }}
-              yq -ei '.init_diagram |= load_str("${TEMPDIR}/d2/${CONTAINER_NAME}-{{ ls_branch }}.d2")' readme-vars.yml || :
+              docker run -d --rm -v ${TEMPDIR}/d2:/output -e PUID=$(id -u) -e PGID=$(id -g) ghcr.io/linuxserver/d2-builder:latest ${CONTAINER_NAME}:{{ release_tag }}
+              yq -ei ".init_diagram |= load_str(\\"${TEMPDIR}/d2/${CONTAINER_NAME}-{{ ls_branch }}.d2\\")" readme-vars.yml || :
               if [[ $(grep -hs ^ readme-vars.yml | md5sum | cut -c1-8) != $(grep -hs ^ ${TEMPDIR}/docker-${CONTAINER_NAME}/readme-vars.yml | md5sum | cut -c1-8) ]]; then
                 echo "'init_diagram' has been updated. Updating repo and exiting build, new one will trigger based on commit."
                 mkdir -p ${TEMPDIR}/repo


### PR DESCRIPTION
Skip custom readme and images containing `init_diagram: false`

Blurb being added to Jenkinsfile was tested locally for the following scenarios:
1) custom readme: not added
2) no `init_diagram`: added
3) `init_diagram: false` in readme-vars.yml: not added

~~The editing of readme-vars.yml, commit and push to github will have to be tested live after merge unfortunately.
I'm not 100% sure the double escapes `\\` in Jenkinsfile are necessary here (I believe they are, but we'll find out after merge for sure).~~
Bash script also tested by manually modifying a synclounge dev branch's Jenkinsfile to manually add an active stage for updating readme-vars.yml.
Git changes to Jenkinsfile here: https://github.com/linuxserver/docker-synclounge/compare/linuxserver:b16e431...linuxserver:48a66f2#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8
First jenkins build: https://ci.linuxserver.io/blue/organizations/jenkins/Docker-Pipeline-Builders%2Fdocker-synclounge/detail/readme-test/10/pipeline/108
Bot commit with readme-vars.yml update: https://github.com/linuxserver/docker-synclounge/commit/48a66f279aabeeef068bdaece75fb38eb8fd9164
Second build: https://ci.linuxserver.io/blue/organizations/jenkins/Docker-Pipeline-Builders%2Fdocker-synclounge/detail/readme-test/11/pipeline/108

## Downsides:
`yq -ie` reformats the readme-vars.yml and makes the following changes:
- Removes all empty lines between yaml keys
- Removes all empty space betwen braces `{` `}` and values (ie. `  - { cap_add_var: "NET_ADMIN" }` becomes `  - {cap_add_var: "NET_ADMIN"}` throughout the readme-vars.yml)

Needs https://github.com/linuxserver/docker-d2-builder/pull/2 merged