### PR TITLE
Fix handling of OCI indexes and manifests

### DIFF
--- a/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
+++ b/roles/generate-jenkins/templates/EXTERNAL_TRIGGER.j2
@@ -108,25 +108,25 @@ jobs:
             "https://ghcr.io/token?scope=repository%3A{{ better_vars.LS_USER }}%2F{{ project_name }}%3Apull" \
             | jq -r '.token')
 {% if better_vars.MULTIARCH == 'true' %}
-            multidigest=$(curl -s \
-              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-              --header "Accept: application/vnd.oci.image.index.v1+json" \
-              --header "Authorization: Bearer ${token}" \
-              "https://ghcr.io/v2/${image}/manifests/${tag}" \
-              | jq -r 'first(.manifests[].digest)')
-            digest=$(curl -s \
-              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-              --header "Accept: application/vnd.oci.image.index.v1+json" \
-              --header "Authorization: Bearer ${token}" \
-              "https://ghcr.io/v2/${image}/manifests/${multidigest}" \
-              | jq -r '.config.digest')
+          multidigest=$(curl -s \
+            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            --header "Accept: application/vnd.oci.image.index.v1+json" \
+            --header "Authorization: Bearer ${token}" \
+            "https://ghcr.io/v2/${image}/manifests/${tag}")
+          multidigest=$(jq -r ".manifests[] | select(.platform.architecture == \"amd64\").digest?" <<< "${multidigest}")
+          digest=$(curl -s \
+            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            --header "Accept: application/vnd.oci.image.manifest.v1+json" \
+            --header "Authorization: Bearer ${token}" \
+            "https://ghcr.io/v2/${image}/manifests/${multidigest}" \
+            | jq -r '.config.digest')
 {% else %}
-            digest=$(curl -s \
-              --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
-              --header "Accept: application/vnd.oci.image.index.v1+json" \
-              --header "Authorization: Bearer ${token}" \
-              "https://ghcr.io/v2/${image}/manifests/${tag}" \
-              | jq -r '.config.digest')
+          digest=$(curl -s \
+            --header "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+            --header "Accept: application/vnd.oci.image.manifest.v1+json" \
+            --header "Authorization: Bearer ${token}" \
+            "https://ghcr.io/v2/${image}/manifests/${tag}" \
+            | jq -r '.config.digest')
 {% endif %}
           image_info=$(curl -sL \
             --header "Authorization: Bearer ${token}" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-jenkins-builder/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
One edge-case caveat to document here:

If we ever do a multi-arch build without amd64 in the future, this will need changing because it assumes there will always be an amd64 manifest to check in multi-arch builds. See line 116.

Another way to do it is to delete all annotations and then just grab the first manifest entry but that's more prone to breaking due to unforeseen changes IMO.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
