### PR TITLE
keep sanitized and raw external versions separate in external trigger

### DIFF
--- a/ansible/roles/github/templates/external_trigger.yml.j2
+++ b/ansible/roles/github/templates/external_trigger.yml.j2
@@ -107,7 +107,7 @@ jobs:
               "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
             exit 1
           fi
-          EXT_RELEASE=$(echo ${EXT_RELEASE} | sed 's/[~,%@+;:/]//g')
+          EXT_RELEASE_SANITIZED=$(echo ${EXT_RELEASE} | sed 's/[~,%@+;:/]//g')
           echo "External version: \`${EXT_RELEASE}\`" >> $GITHUB_STEP_SUMMARY
           echo "Retrieving last pushed version" >> $GITHUB_STEP_SUMMARY
           image="{{ better_vars.LS_USER }}/{{ project_name }}"
@@ -164,7 +164,7 @@ jobs:
             exit 1
           fi
           echo "Last pushed version: \`${IMAGE_VERSION}\`" >> $GITHUB_STEP_SUMMARY
-          if [ "${EXT_RELEASE}" == "${IMAGE_VERSION}" ]; then
+          if [ "${EXT_RELEASE_SANITIZED}" == "${IMAGE_VERSION}" ]; then
             echo "Version \`${EXT_RELEASE}\` already pushed, exiting" >> $GITHUB_STEP_SUMMARY
             exit 0
 {% if external_type == "alpine_repo" and better_vars.MULTIARCH == 'true' %}
@@ -197,7 +197,7 @@ jobs:
                 "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}
             else
               printf "\n## Trigger new build\n\n" >> $GITHUB_STEP_SUMMARY
-              echo "New version \`${EXT_RELEASE}\` found; old version was \`${IMAGE_VERSION}\`. Triggering new build" >> $GITHUB_STEP_SUMMARY
+              echo "New sanitized version \`${EXT_RELEASE_SANITIZED}\` found; old version was \`${IMAGE_VERSION}\`. Triggering new build" >> $GITHUB_STEP_SUMMARY
               if [[ "${artifacts_found}" == "true" ]]; then
                 echo "All artifacts seem to be uploaded." >> $GITHUB_STEP_SUMMARY
               fi
@@ -217,7 +217,7 @@ jobs:
                 --data-urlencode "description=GHA external trigger https://github.com/${{ '{{' }} github.repository {{ '}}' }}/actions/runs/${{ '{{' }} github.run_id {{ '}}' }}" \
                 --data-urlencode "Submit=Submit"
               echo "**** Notifying Discord ****"
-              TRIGGER_REASON="A version change was detected for {{ project_name }} tag {{ release_tag }}. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE}"
+              TRIGGER_REASON="A version change was detected for {{ project_name }} tag {{ release_tag }}. Old version:${IMAGE_VERSION} New version:${EXT_RELEASE_SANITIZED}"
               curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
                 "description": "**Build Triggered** \n**Reason:** '"${TRIGGER_REASON}"' \n**Build URL:** '"${buildurl}display/redirect"' \n"}],
                 "username": "Github Actions"}' ${{ '{{' }} secrets.DISCORD_WEBHOOK {{ '}}' }}


### PR DESCRIPTION
Currently we are sanitizing the external version and overwriting the variable. That causes unwanted issues when we later try to use that var value to check for artifacts.

This PR separates the raw and the sanitized versions of the var and uses the sanitized version only to check against the last pushed image version.