### PR TITLE
Retrieve syft image tag from jenkins env vars, default to latest

### DIFF
--- a/ansible/roles/repository/templates/Jenkinsfile.j2
+++ b/ansible/roles/repository/templates/Jenkinsfile.j2
@@ -1214,7 +1214,7 @@ pipeline {
                 -e WEB_AUTH=\"${CI_AUTH}\" \
                 -e WEB_PATH=\"${CI_WEBPATH}\" \
                 -e NODE_NAME=\"${NODE_NAME}\" \
-                -e SYFT_IMAGE_TAG=\"${SYFT_IMAGE_TAG}\" \
+                -e SYFT_IMAGE_TAG=\"${CI_SYFT_IMAGE_TAG:${SYFT_IMAGE_TAG}}\" \
                 -t ghcr.io/linuxserver/ci:latest \
                 python3 test_build.py'''
         }


### PR DESCRIPTION
- Retrieve env var `SYFT_IMAGE_TAG` from jenkins env vars and use it for package check
- Attempt to pass the value of an optional `CI_SYFT_IMAGE_TAG` var to ci container with fall back to the value of `SYFT_IMAGE_TAG`
- If unset, default to tag `latest`

Test when var is unset on jenkins (defaulted to `latest`):
https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-synclounge/job/jenkinstest/3/pipeline-overview/?selected-node=34
Test when var is set to `v1.26.1`:
https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-synclounge/job/jenkinstest/4/pipeline-overview/?selected-node=34

Needs to be merged before https://github.com/linuxserver/docker-ci/pull/63 and the jenkins env `SYFT_IMAGE_TAG=v1.26.1` set at the time.