### PR TITLE
check for riscv64 artifacts

### DIFF
--- a/ansible/roles/github/templates/external_trigger.yml.j2
+++ b/ansible/roles/github/templates/external_trigger.yml.j2
@@ -170,8 +170,8 @@ jobs:
           if [ "${EXT_RELEASE_SANITIZED}" == "${IMAGE_VERSION}" ]; then
             echo "Sanitized version \`${EXT_RELEASE_SANITIZED}\` already pushed, exiting" >> $GITHUB_STEP_SUMMARY
             exit 0
-{% if external_type == "alpine_repo" and better_vars.MULTIARCH == 'true' %}
-          elif [[ $(curl -sL "{{ better_vars.DIST_REPO }}aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% if build_armhf %} || [[ $(curl -sL "{{ better_vars.DIST_REPO }}armv7/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% endif %}; then
+{% if external_type == "alpine_repo" and (better_vars.MULTIARCH == 'true' or build_riscv64) %}
+          elif [[ $(curl -sL "{{ better_vars.DIST_REPO }}aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% if build_armhf %} || [[ $(curl -sL "{{ better_vars.DIST_REPO }}armv7/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% endif %}{% if build_riscv64 %} || [[ $(curl -sL "{{ better_vars.DIST_REPO }}riscv64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% endif %}; then
             echo "New version \`${EXT_RELEASE}\` found; but not all arch repos updated yet; exiting" >> $GITHUB_STEP_SUMMARY
             FAILURE_REASON="New version ${EXT_RELEASE} for {{ project_name }} tag {{ release_tag }} is detected, however not all arch repos are updated yet. Will try again later."
             curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,

--- a/ansible/roles/github/templates/external_trigger.yml.j2
+++ b/ansible/roles/github/templates/external_trigger.yml.j2
@@ -170,7 +170,7 @@ jobs:
           if [ "${EXT_RELEASE_SANITIZED}" == "${IMAGE_VERSION}" ]; then
             echo "Sanitized version \`${EXT_RELEASE_SANITIZED}\` already pushed, exiting" >> $GITHUB_STEP_SUMMARY
             exit 0
-{% if external_type == "alpine_repo" and (better_vars.MULTIARCH == 'true' or build_riscv64) %}
+{% if external_type == "alpine_repo" and better_vars.MULTIARCH == 'true' %}
           elif [[ $(curl -sL "{{ better_vars.DIST_REPO }}aarch64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% if build_armhf %} || [[ $(curl -sL "{{ better_vars.DIST_REPO }}armv7/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% endif %}{% if build_riscv64 %} || [[ $(curl -sL "{{ better_vars.DIST_REPO }}riscv64/APKINDEX.tar.gz" | tar -xz -C /tmp && awk '/^P:'"{{ better_vars.DIST_REPO_PACKAGES }}"'$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://') != "${EXT_RELEASE}" ]]{% endif %}; then
             echo "New version \`${EXT_RELEASE}\` found; but not all arch repos updated yet; exiting" >> $GITHUB_STEP_SUMMARY
             FAILURE_REASON="New version ${EXT_RELEASE} for {{ project_name }} tag {{ release_tag }} is detected, however not all arch repos are updated yet. Will try again later."


### PR DESCRIPTION
also check for riscv64 artifact when `build_riscv64` is set to `true` when `external_type` is `alpine_repo`