### PR TITLE
add custom ws port to selkies blurb

### DIFF
--- a/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
+++ b/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
@@ -20,6 +20,7 @@ This container is based on [Docker Baseimage Selkies](https://github.com/linuxse
 | :----: | --- |
 | `CUSTOM_PORT` | Internal HTTP port. Defaults to `{% if external_http_port is defined %}{{ external_http_port }}{% else %}3000{% endif %}`. |
 | `CUSTOM_HTTPS_PORT` | Internal HTTPS port. Defaults to `{% if external_https_port is defined %}{{ external_https_port }}{% else %}3001{% endif %}`. |
+| `CUSTOM_WS_PORT` | Internal port the container listens on for websockets if it needs to be swapped from the default 8082. |
 | `CUSTOM_USER` | Username for HTTP Basic Auth. Defaults to `abc`. |
 | `PASSWORD` | Password for HTTP Basic Auth. If unset, authentication is disabled. |
 | `SUBFOLDER` | Application subfolder for reverse proxy configurations. Must include leading and trailing slashes, e.g., `/subfolder/`. |


### PR DESCRIPTION
New env var in the bases to set the custom websocket port so users can mix these desktop containers on the same network interface. 