### PR TITLE
use github generated release notes for LS changes

### DIFF
--- a/ansible/roles/repository/templates/Jenkinsfile.j2
+++ b/ansible/roles/repository/templates/Jenkinsfile.j2
@@ -1313,9 +1313,15 @@ pipeline {
       }
       steps {
         echo "Auto-generating release notes"
-        sh '''AUTO_RELEASE_NOTES=$(curl -fsL -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases/generate-notes  \
-        -d '{"tag_name":"'${META_TAG}'",\
-             "target_commitish": "{{ ls_branch }}"}' | jq -r '.body' | sed 's|## What.s Changed||') '''
+        sh '''if [ "$(git tag --points-at HEAD)" != "" ]; then
+            echo "Existing tag points to current commit, suggesting no new LS changes"
+            AUTO_RELEASE_NOTES="No changes"
+          else
+            AUTO_RELEASE_NOTES=$(curl -fsL -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases/generate-notes  \
+              -d '{"tag_name":"'${META_TAG}'",\
+                  "target_commitish": "{{ ls_branch }}"}' \
+              | jq -r '.body' | sed 's|## What.s Changed||')
+          fi'''
         echo "Pushing New tag for current commit ${META_TAG}"
         sh '''curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/git/tags \
         -d '{"tag":"'${META_TAG}'",\


### PR DESCRIPTION
Merged PRs are listed individually.
For commits, it includes a link to the commit history since the last tag
Nice thing is, it determines the last tag automatically based on branch defined

- The PRs we merge for rebases and fixes and such would be listed individually with some details and specific links
- If there are only package updates by the bot, there would be a link to an accurate changelog with all the commits since the last tag.
- ~~However, if the new release includes an upstream version update only, no package updates and the upstream app's version is not listed in the package_versions.txt, this method would list the changelog between the prior tag (as opposed to latest) and the new prpoposed tag. It wouldn't be inaccurate, but it would be misleading.~~ It now checks to see if the current commit is associated with a tag and if so, it prints `No Changes` under the LS changes section.

Here are some examples:

Release with PRs: https://github.com/aptalca/test/releases/tag/1.0.1
Release with No PRs, just commits: https://github.com/aptalca/test/releases/tag/test-1.0.1
Release with just commits and no previous tag: https://github.com/aptalca/test/releases/tag/test-1.0.0

EDIT: Switched to jq for generating our release body because sanitization became a nightmare. The above releases were created by copy pasting the api call output into a manually created released.

The following release was created entirely via cli, mimicking the Jenkinsfile commands as closely as possible: https://github.com/aptalca/test/releases/tag/140.0.7339.80-1-ls36