### PR TITLE
sync snippet with baseimge to advertise all container settings

### DIFF
--- a/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
+++ b/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
@@ -36,6 +36,7 @@ This container is based on [Docker Baseimage Selkies](https://github.com/linuxse
 | LC_ALL | Set the Language for the container to run as IE `fr_FR.UTF-8` `ar_AE.UTF-8` |
 | NO_DECOR | If set the application will run without window borders for use as a PWA. (Decor can be enabled and disabled with Ctrl+Shift+d) |
 | NO_FULL | Do not autmatically fullscreen applications when using openbox. |
+| NO_GAMEPAD | Disable userspace gamepad interposer injection. |
 | DISABLE_ZINK | Do not set the Zink environment variables if a video card is detected (userspace applications will use CPU rendering) |
 | DISABLE_DRI3 | Do not use DRI3 acceleration if a video card is detected (userspace applications will use CPU rendering) |
 | MAX_RES | Pass a larger maximum resolution for the container default is 16k `15360x8640` |


### PR DESCRIPTION
Syncs up the baseimage docs for the snippet. 