### PR TITLE
Pass the COMMIT_SHA and BUILD_NUMBER env to the CI container so we ca…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -860,6 +860,8 @@ pipeline {
                 -e WEB_PATH=\"${CI_WEBPATH}\" \
                 -e NODE_NAME=\"${NODE_NAME}\" \
                 -e SYFT_IMAGE_TAG=\"${CI_SYFT_IMAGE_TAG:-${SYFT_IMAGE_TAG}}\" \
+                -e COMMIT_SHA=\"${COMMIT_SHA}\" \
+                -e BUILD_NUMBER=\"${BUILD_NUMBER}\" \
                 -t ghcr.io/linuxserver/ci:${CITEST_IMAGETAG} \
                 python3 test_build.py'''
         }


### PR DESCRIPTION
This https://github.com/linuxserver/docker-ci/pull/68 needs this to make buildx imagetools inspect work,