### PR TITLE
send CI link to PR comment even when the test fails

### DIFF
--- a/ansible/roles/repository/templates/Jenkinsfile.j2
+++ b/ansible/roles/repository/templates/Jenkinsfile.j2
@@ -61,6 +61,7 @@ pipeline {
            '''
         script{
           env.EXIT_STATUS = ''
+          env.CI_TEST_COMPLETED = ''
           env.LS_RELEASE = sh(
             script: '''docker run --rm quay.io/skopeo/stable:v1 inspect docker://ghcr.io/${LS_USER}/${CONTAINER_NAME}:{{ release_tag }} 2>/dev/null | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
             returnStdout: true).trim()
@@ -1233,6 +1234,9 @@ pipeline {
                 -e BUILD_NUMBER=\"${BUILD_NUMBER}\" \
                 -t ghcr.io/linuxserver/ci:${CITEST_IMAGETAG} \
                 python3 test_build.py'''
+          script{
+            env.CI_TEST_COMPLETED = 'true'
+          }
         }
       }
     }
@@ -1441,7 +1445,7 @@ EOF
     stage('Pull Request Comment') {
       when {
         not {environment name: 'CHANGE_ID', value: ''}
-        environment name: 'EXIT_STATUS', value: ''
+        environment name: 'CI_TEST_COMPLETED', value: 'true'
       }
       steps {
         sh '''#! /bin/bash


### PR DESCRIPTION
Currently the CI test results are added to PRs as comments only if the build succeeds. However, it is very useful to know when the build fails as a result of the CI test failing, as it suggests a runtime issue.

Another issue is, if a PR has a commit with a successful CI test, followed by a commit with a failing CI test, the comments in the PR will be misleading as the last comment will show a successful build.

This PR ensures that the PR comment is added every time the CI test is completed, whether successful or not.