### PR TITLE
update nvidia section of the blurb to reflect fully tested state while adding unraid specifics

### DIFF
--- a/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
+++ b/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
@@ -54,13 +54,24 @@ For Intel and AMD GPUs.
 
 {% if show_nvidia is defined %}##### Nvidia (Proprietary Drivers)
 
+
 **Note: Nvidia support is not available for Alpine-based images.**
 
 **Prerequisites:**
 
-1. **Driver:** Proprietary drivers **580 or higher** are required.
-2. **Kernel Parameter:** Set `nvidia-drm.modeset=1` in your host bootloader (GRUB/systemd-boot).
-3. **Initialization:** On headless systems, run `nvidia-modprobe --modeset` on the host (once per boot) to initialize the card.
+1. **Driver:** Proprietary drivers **580 or higher** are required. **Crucially, you should install the driver using the `.run` file downloaded directly from the Nvidia website.**
+   * **Unraid:** Use the production branch from the Nvidia Driver Plugin.
+2. **Kernel Parameter:** You must set `nvidia-drm.modeset=1` in your host bootloader. 
+   * **Standard Linux (GRUB):** Edit `/etc/default/grub` and add the parameter to your existing `GRUB_CMDLINE_LINUX_DEFAULT` line:
+     ```text
+     GRUB_CMDLINE_LINUX_DEFAULT="<other existing options> nvidia-drm.modeset=1"
+     ```
+     Then apply the changes by running:
+     ```bash
+     sudo update-grub
+     ```
+   * **Unraid (Syslinux):** Edit the file `/boot/syslinux/syslinux.cfg` and add `nvidia-drm.modeset=1` to the end of the `append` line for the Unraid OS boot entry.
+3. **Hardware Initialization:** **On headless systems, the Nvidia video card requires a physical dummy plug inserted into the GPU so that DRM initializes properly.**
 4. **Docker Runtime:** Configure the host docker daemon to use the Nvidia runtime:
 
     ```bash
@@ -88,6 +99,9 @@ services:
               count: 1
               capabilities: [compute,video,graphics,utility]
 ```
+
+* **Unraid:** Ensure you're properly setting the DRINODE/DRI_NODE and adding `--gpus all --runtime nvidia` to your extra parameters.
+
 {% endif %}
 
 ### SealSkin Compatibility


### PR DESCRIPTION
Had a long support thread on this one for Unraid and discovered the dummy plug is mandatory.

Also expanded the kernel setting so people understand where to set it.