### PR TITLE
note lack of nvidia support on unraid

### DIFF
--- a/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
+++ b/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
@@ -227,10 +227,9 @@ For Intel and AMD GPUs.
 **Prerequisites:**
 
 1. **Driver:** Proprietary drivers **580 or higher** are required. **Crucially, you should install the driver using the `.run` file downloaded directly from the Nvidia website.**
-    * **Unraid:** Use the production branch from the Nvidia Driver Plugin.
 
 2. **Kernel Parameter:** You must set `nvidia-drm.modeset=1 nvidia_drm.fbdev=1` in your host bootloader.
-    * **Standard Linux (GRUB):** Edit `/etc/default/grub` and add the parameter to your existing `GRUB_CMDLINE_LINUX_DEFAULT` line:
+    * **GRUB:** Edit `/etc/default/grub` and add the parameter to your existing `GRUB_CMDLINE_LINUX_DEFAULT` line:
 
         ```text
         GRUB_CMDLINE_LINUX_DEFAULT="<other existing options> nvidia-drm.modeset=1 nvidia_drm.fbdev=1"
@@ -241,8 +240,6 @@ For Intel and AMD GPUs.
         ```bash
         sudo update-grub
         ```
-
-    * **Unraid (Syslinux):** Edit the file `/boot/syslinux/syslinux.cfg` and add `nvidia-drm.modeset=1 nvidia_drm.fbdev=1` to the end of the `append` line for the Unraid OS boot entry.
 
 3. **Hardware Initialization:** **On headless systems, the Nvidia video card requires a physical dummy plug inserted into the GPU so that DRM initializes properly.**
 
@@ -274,7 +271,9 @@ services:
               capabilities: [compute,video,graphics,utility]
 ```
 
-* **Unraid:** Ensure you're properly setting the DRINODE/DRI_NODE and adding `--gpus all --runtime nvidia` to your extra parameters.
+**Nvidia Unraid is not supported:**
+
+Unraid's official Nvidia driver package does not conform to NVIDIA Container Toolkit standards. On top of improper pathing, whole sections of the driver tree are missing and are not mounted into the container at runtime. This is the only known incompatible Linux operating system at this time.
 
 {% endif %}
 ### SealSkin Compatibility


### PR DESCRIPTION
After some local troubleshooting installing unraid on my own system it was found that the nvidia container toolkit on Unraid is not mounting in the right files or setting up pathing adjustments for underlying containers properly. 

Findings: 

https://github.com/linuxserver/docker-baseimage-selkies/issues/146#issuecomment-4232591393

This all boils down to new requirements for running a wayland surface via an EGL accelerated GBM on the nvidia card itself to enable zero copy encoding and native 3D acceleration support. Normally the nvidia container toolkit handles all of this and the drivers are mounted into the container and adapted to the containers pathing (IE Arch host with a Debian container). 

The new stack works by making a wayland surface just like an application running on a normal Linux desktop would, we then nest a whole desktop environment into that surface. This type of native Linux Wayland support was introduced in Nvidia 555 with explicit sync support and enables multi tenancy vdi, zero copy encoding, and other modern features. Legacy stacks used a static Xorg config and priv mode in most cases to run xorg dummy in the container, these do not require the same `so` files for support. The same goes for basic stuff like nvenc or cuda. 