### PR TITLE
add PR comment on ci false, switch manifestimage setting to if block

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1152,12 +1152,12 @@ EOF
                     curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
                       -H "Accept: application/vnd.github.v3+json" \
                       "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
-                      -d "{\\"body\\": \\"I am a bot, here are the test results for this PR: \\n${CI_URL}\\n${SHELLCHECK_URL}\\n${table}\\"}"
+                      -d "{\\"body\\": \\"I am a bot, here are the test results for this PR for commit ${COMMIT_SHA:0:7} : \\n${CI_URL}\\n${SHELLCHECK_URL}\\n${table}\\"}"
                   else
                     curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
                       -H "Accept: application/vnd.github.v3+json" \
                       "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
-                      -d "{\\"body\\": \\"I am a bot, here is the pushed image/manifest for this PR: \\n\\n\\`${GITHUBIMAGE}:${META_TAG}\\`\\"}"
+                      -d "{\\"body\\": \\"I am a bot, here is the pushed image/manifest for this PR for commit ${COMMIT_SHA:0:7} : \\n\\n\\`${GITHUBIMAGE}:${META_TAG}\\`\\"}"
                   fi
                   '''
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,7 @@ pipeline {
         script{
           env.EXIT_STATUS = ''
           env.CI_TEST_ATTEMPTED = ''
+          env.PUSH_ATTEMPTED = ''
           env.LS_RELEASE = sh(
             script: '''docker run --rm quay.io/skopeo/stable:v1 inspect docker://ghcr.io/${LS_USER}/${CONTAINER_NAME}:latest 2>/dev/null | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
             returnStdout: true).trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -879,6 +879,9 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
+        script{
+          env.PUSH_ATTEMPTED = 'true'
+        }
         retry_backoff(5,5) {
           sh '''#! /bin/bash
                 set -e
@@ -908,11 +911,18 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
+        script{
+          env.PUSH_ATTEMPTED = 'true'
+        }
         retry_backoff(5,5) {
           sh '''#! /bin/bash
                 set -e
                 for MANIFESTIMAGE in "${IMAGE}" "${GITLABIMAGE}" "${GITHUBIMAGE}" "${QUAYIMAGE}"; do
-                  [[ ${MANIFESTIMAGE%%/*} =~ \\. ]] && MANIFESTIMAGEPLUS="${MANIFESTIMAGE}" || MANIFESTIMAGEPLUS="docker.io/${MANIFESTIMAGE}"
+                  if [[ "${MANIFESTIMAGE%%/*}" =~ \\. ]]; then
+                    MANIFESTIMAGEPLUS="${MANIFESTIMAGE}"
+                  else
+                    MANIFESTIMAGEPLUS="docker.io/${MANIFESTIMAGE}"
+                  fi
                   IFS=',' read -ra CACHE <<< "$BUILDCACHE"
                   for i in "${CACHE[@]}"; do
                       if [[ "${MANIFESTIMAGEPLUS}" == "$(cut -d "/" -f1 <<< ${i})"* ]]; then
@@ -1080,7 +1090,7 @@ EOF
       }
       script {
         if (env.GITHUBIMAGE =~ /lspipepr/){
-          if (env.CI_TEST_ATTEMPTED == "true"){
+          if (env.CI_TEST_ATTEMPTED == "true" || env.PUSH_ATTEMPTED == "true"){
             sh '''#! /bin/bash
                   # Function to retrieve JSON data from URL
                   get_json() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1160,6 +1160,13 @@ EOF
                       -d "{\\"body\\": \\"I am a bot, here is the pushed image/manifest for this PR for commit ${COMMIT_SHA:0:7} : \\n\\n\\`${GITHUBIMAGE}:${META_TAG}\\`\\"}"
                   fi
                   '''
+          } else {
+            sh '''#! /bin/bash
+                  curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
+                    -d "{\\"body\\": \\"I am a bot, the build for PR commit ${COMMIT_SHA:0:7} failed and as a result no CI test was attempted and no images were pushed.\\"}"
+            '''
           }
         }
       }

--- a/ansible/roles/repository/templates/Jenkinsfile.j2
+++ b/ansible/roles/repository/templates/Jenkinsfile.j2
@@ -1584,12 +1584,12 @@ EOF
                     curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
                       -H "Accept: application/vnd.github.v3+json" \
                       "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
-                      -d "{\\"body\\": \\"I am a bot, here are the test results for this PR: \\n${CI_URL}\\n${SHELLCHECK_URL}\\n${table}\\"}"
+                      -d "{\\"body\\": \\"I am a bot, here are the test results for this PR for commit ${COMMIT_SHA:0:7} : \\n${CI_URL}\\n${SHELLCHECK_URL}\\n${table}\\"}"
                   else
                     curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
                       -H "Accept: application/vnd.github.v3+json" \
                       "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
-                      -d "{\\"body\\": \\"I am a bot, here is the pushed image/manifest for this PR: \\n\\n\\`${GITHUBIMAGE}:${META_TAG}\\`\\"}"
+                      -d "{\\"body\\": \\"I am a bot, here is the pushed image/manifest for this PR for commit ${COMMIT_SHA:0:7} : \\n\\n\\`${GITHUBIMAGE}:${META_TAG}\\`\\"}"
                   fi
                   '''
           }

--- a/ansible/roles/repository/templates/Jenkinsfile.j2
+++ b/ansible/roles/repository/templates/Jenkinsfile.j2
@@ -62,6 +62,7 @@ pipeline {
         script{
           env.EXIT_STATUS = ''
           env.CI_TEST_ATTEMPTED = ''
+          env.PUSH_ATTEMPTED = ''
           env.LS_RELEASE = sh(
             script: '''docker run --rm quay.io/skopeo/stable:v1 inspect docker://ghcr.io/${LS_USER}/${CONTAINER_NAME}:{{ release_tag }} 2>/dev/null | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
             returnStdout: true).trim()

--- a/ansible/roles/repository/templates/Jenkinsfile.j2
+++ b/ansible/roles/repository/templates/Jenkinsfile.j2
@@ -1248,6 +1248,9 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
+        script{
+          env.PUSH_ATTEMPTED = 'true'
+        }
         retry_backoff(5,5) {
           sh '''#! /bin/bash
                 set -e
@@ -1280,11 +1283,18 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
+        script{
+          env.PUSH_ATTEMPTED = 'true'
+        }
         retry_backoff(5,5) {
           sh '''#! /bin/bash
                 set -e
                 for MANIFESTIMAGE in "${IMAGE}" "${GITLABIMAGE}" "${GITHUBIMAGE}" "${QUAYIMAGE}"; do
-                  [[ ${MANIFESTIMAGE%%/*} =~ \\. ]] && MANIFESTIMAGEPLUS="${MANIFESTIMAGE}" || MANIFESTIMAGEPLUS="docker.io/${MANIFESTIMAGE}"
+                  if [[ "${MANIFESTIMAGE%%/*}" =~ \\. ]]; then
+                    MANIFESTIMAGEPLUS="${MANIFESTIMAGE}"
+                  else
+                    MANIFESTIMAGEPLUS="docker.io/${MANIFESTIMAGE}"
+                  fi
                   IFS=',' read -ra CACHE <<< "$BUILDCACHE"
                   for i in "${CACHE[@]}"; do
                       if [[ "${MANIFESTIMAGEPLUS}" == "$(cut -d "/" -f1 <<< ${i})"* ]]; then
@@ -1512,7 +1522,7 @@ EOF
       }
       script {
         if (env.GITHUBIMAGE =~ /lspipepr/){
-          if (env.CI_TEST_ATTEMPTED == "true"){
+          if (env.CI_TEST_ATTEMPTED == "true" || env.PUSH_ATTEMPTED == "true"){
             sh '''#! /bin/bash
                   # Function to retrieve JSON data from URL
                   get_json() {

--- a/ansible/roles/repository/templates/Jenkinsfile.j2
+++ b/ansible/roles/repository/templates/Jenkinsfile.j2
@@ -1592,6 +1592,13 @@ EOF
                       -d "{\\"body\\": \\"I am a bot, here is the pushed image/manifest for this PR for commit ${COMMIT_SHA:0:7} : \\n\\n\\`${GITHUBIMAGE}:${META_TAG}\\`\\"}"
                   fi
                   '''
+          } else {
+            sh '''#! /bin/bash
+                  curl -X POST -H "Authorization: token $GITHUB_TOKEN" \
+                    -H "Accept: application/vnd.github.v3+json" \
+                    "https://api.github.com/repos/$LS_USER/$LS_REPO/issues/$PULL_REQUEST/comments" \
+                    -d "{\\"body\\": \\"I am a bot, the build for PR commit ${COMMIT_SHA:0:7} failed and as a result no CI test was attempted and no images were pushed.\\"}"
+            '''
           }
         }
       }


### PR DESCRIPTION
- Moving the PR comment block to `post` section required us to define run conditions very specifically. We previously accounted for CI test attempt, but failed to account for when CI tests are disabled in the main if condition. This PR accounts for the scenario where CI tests are disabled, but the build progressed to the push stage by introducing a stage set var `PUSH_ATTEMPTED`.
- Changes a conditional block in manifest image generation to a proper if block with the var wrapped in double quotes. The main reason was cosmetic as the missing quotes messed up the code rendering of the rest of the jenkinsfile template.
- Implements a PR comment message with a commit link when a build fails before reaching CI test or image push stages.