### PR TITLE
remove note on nvidia being experimental it is solid now

### DIFF
--- a/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
+++ b/ansible/roles/documentation/templates/README_SNIPPETS/SELKIES.j2
@@ -224,8 +224,6 @@ For Intel and AMD GPUs.
 
 ##### Nvidia (Proprietary Drivers)
 
-**Note: Nvidia support is currently considered experimental, driver changes can break it at any time.**
-
 **Note: Nvidia support is not available for Alpine-based images.**
 
 **Prerequisites:**


### PR DESCRIPTION
595 works all clients work now that the decoder setup has been updated and 4:4:4 no reason to mark it experimental. 